### PR TITLE
Fix hot reducer loading in examples/real-world

### DIFF
--- a/examples/real-world/store/configureStore.dev.js
+++ b/examples/real-world/store/configureStore.dev.js
@@ -16,7 +16,7 @@ export default function configureStore(initialState) {
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('../reducers', () => {
-      const nextRootReducer = require('../reducers')
+      const nextRootReducer = require('../reducers').default
       store.replaceReducer(nextRootReducer)
     })
   }


### PR DESCRIPTION
As raised in #9, hot reducer loading is currently broken. The problem is that Babel 6 changed how default exports are stored:

```js
// a.js
export default 'hello'

// b.js, Babel 5
const hi = require('./a')
assert(hi === 'hello')

// b.js, Babel 6
const hi = require('./a')
assert(hi !== 'hello')
assert(hi.default === 'hello')
```