### PR TITLE
Add missing npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,5 +570,6 @@ npm run build-async
 real-world example (with webpack hot reloading)
 ```
 cd examples/real-world
+npm install
 npm start
 ```


### PR DESCRIPTION
The instructions of the 'real word example' where missing an 'npm install'.