### PR TITLE
Add support to umd builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 
 # compiled js files
 lib
+
+# compiled umd js files
+dist

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ dialogs, complex Game rules ...), which are not trivial to express using other e
 - [Composing Sagas](#composing-sagas)
 - [Non blocking calls with fork/join](#non-blocking-calls-with-forkjoin)
 - [Building examples from sources](#building-examples-from-sources)
+- [Using umd build in the browser](#using-umd-build-in-the-browser)
 
 #Getting started
 
@@ -515,7 +516,6 @@ You can also ask a Task if it's still running
 const stillRunning = task.isRunning()
 ```
 
-
 #Building examples from sources
 
 Pre-requisites
@@ -576,3 +576,14 @@ cd examples/real-world
 npm install
 npm start
 ```
+
+#Using umd build in the browser
+
+There's an **umd** build of `redux-saga` available in `dist/` folder. Using the umd build `redux-saga` is available as `ReduxSaga` in the window object.
+The umd version is useful if you don't use webpack or browserify, you can access it directly from [npmcdn](npmcdn.com).
+The following builds are available:
+[https://npmcdn.com/redux-saga/dist/redux-saga.js](https://npmcdn.com/redux-saga/dist/redux-saga.js)
+[https://npmcdn.com/redux-saga/dist/redux-saga.min.js](https://npmcdn.com/redux-saga/dist/redux-saga.min.js)
+
+**Important!** If the browser you are targeting doesn't support _es2015 generators_ you must provide a valid polyfill, for example the one provided by *babel*: [browser-polyfill.min.js](https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.25/browser-polyfill.min.js). The polyfill must be imported before **redux-saga**.
+

--- a/package.json
+++ b/package.json
@@ -8,22 +8,20 @@
     "test": "babel-node test/index.js | tap-spec",
     "check": "npm run lint && npm run test",
     "compile": "rimraf lib && babel -d lib/ src/",
-    "prepublish": "npm run check && npm run compile",
-
+    "build:umd:dev": "webpack src/index.js dist/redux-saga.js --config webpack.config.dev.js",
+    "build:umd:prod": "webpack src/index.js dist/redux-saga.min.js --config webpack.config.prod.js",
+    "build:umd": "rimraf dist && npm run build:umd:dev && npm run build:umd:prod",
+    "prepublish": "npm run check && npm run compile && npm run build:umd",
     "counter": "budo examples/counter/src/main.js:build.js --dir examples/counter --verbose  --live -- -t babelify",
     "build-counter": "browserify --debug examples/counter/src/main.js -t babelify --outfile examples/counter/build.js",
     "test-counter": "babel-node examples/counter/test/sagas.js | tap-spec",
-
     "shop": "budo examples/shopping-cart/src/main.js:build.js --dir examples/shopping-cart --verbose  --live -- -t babelify",
     "build-shop": "browserify --debug examples/shopping-cart/src/main.js -t babelify --outfile examples/shopping-cart/build.js",
     "test-shop": "babel-node examples/shopping-cart/test/sagas.js | tap-spec",
-
     "async": "budo examples/async/src/main.js:build.js --dir examples/async --verbose  --live -- -t babelify",
     "build-async": "browserify --debug examples/async/src/main.js -t babelify --outfile examples/async/build.js",
-
     "build-examples": "npm run build-counter && npm run build-shop && npm run build-async",
     "test-examples": "npm run test-counter && npm run test-shop",
-
     "real-world": "node examples/real-world/server.js"
   },
   "repository": {
@@ -47,8 +45,10 @@
   "dependencies": {},
   "devDependencies": {
     "babel-cli": "^6.1.18",
+    "babel-core": "6.4.0",
     "babel-eslint": "^4.1.5",
-    "babel-polyfill": "^6.2.0",
+    "babel-loader": "6.2.1",
+    "babel-polyfill": "6.3.14",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-2": "^6.1.18",
@@ -62,6 +62,16 @@
     "redux-logger": "^2.0.4",
     "rimraf": "^2.4.3",
     "tap-spec": "^4.1.1",
-    "tape": "^4.2.2"
-  }
+    "tape": "^4.2.2",
+    "webpack": "1.12.10"
+  },
+  "npmName": "redux-saga",
+  "npmFileMap": [
+    {
+      "basePath": "/dist/",
+      "files": [
+        "*.js"
+      ]
+    }
+  ]
 }

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loaders: ['babel-loader'],
+        exclude: /node_modules/
+      }
+    ]
+  },
+  output: {
+    library: 'ReduxSaga',
+    libraryTarget: 'umd'
+  },
+  resolve: {
+    extensions: ['', '.js']
+  }
+};

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var webpack = require('webpack');
+var baseConfig = require('./webpack.config.base');
+
+var config = Object.create(baseConfig);
+config.plugins = [
+  new webpack.optimize.OccurenceOrderPlugin(),
+  new webpack.DefinePlugin({
+    'process.env.NODE_ENV': JSON.stringify('development')
+  })
+];
+
+module.exports = config;

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var webpack = require('webpack');
+var baseConfig = require('./webpack.config.base');
+
+var config = Object.create(baseConfig);
+config.plugins = [
+  new webpack.optimize.OccurenceOrderPlugin(),
+  new webpack.DefinePlugin({
+    'process.env.NODE_ENV': JSON.stringify('production')
+  }),
+  new webpack.optimize.UglifyJsPlugin({
+    compressor: {
+      screw_ie8: true,
+      warnings: false
+    }
+  })
+];
+
+module.exports = config;


### PR DESCRIPTION
I've added support to generate valid umd builds using webpack. 
In production I use webpack/browserify too but often I need to create snippets or examples easy to share. Without an umd build this results nearly impossible.
Working on a blog post (WIP) on your library I've had workaround the problem, you can se a [jsbin](https://jsbin.com/vacasi/edit?html,js,console) using the new umd build.

I've already added instruction on the readme, let me know if you'd like something different.

Anyway thanks for the library, you're doing a great work on it!