### PR TITLE
add `budo` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-2": "^6.1.18",
     "babelify": "^7.2.0",
+    "budo": "^8.0.0",
     "eslint": "^1.9.0",
     "isomorphic-fetch": "^2.2.0",
     "react": "^0.14.3",


### PR DESCRIPTION
add `bodo` into dev dependencies, which is required by `npm run counter` and other examples