### PR TITLE
Create examples & tests for tasks

### DIFF
--- a/examples/tasks/actions.js
+++ b/examples/tasks/actions.js
@@ -1,0 +1,24 @@
+export const SYNC_START = 'SYNC_START';
+export const SYNC_STOP = 'SYNC_STOP';
+export const SYNC_STOPPED = 'SYNC_STOPPED';
+export const SYNC_ITEM = 'SYNC_ITEM';
+
+export function startSyncing(itemId, interval = 5000) {
+  return {
+    type: SYNC_START,
+    payload: { itemId, interval }
+  };
+}
+
+export function stopSyncing() {
+  return {
+    type: SYNC_STOP
+  };
+}
+
+export function syncItem(itemId) {
+  return {
+    type: SYNC_ITEM,
+    payload: { itemId }
+  }
+}

--- a/examples/tasks/taskSagas.js
+++ b/examples/tasks/taskSagas.js
@@ -1,0 +1,56 @@
+/* eslint-disable no-constant-condition */
+import { take, put, call, fork, cancel, SagaCancellationException } from '../../src';
+import { SYNC_START, SYNC_STOP, SYNC_STOPPED, syncItem } from './actions';
+
+const delay = (millis) => new Promise(resolve => setTimeout(() => resolve(true), millis) );
+
+export function* itemSyncTask(itemId, interval) {
+  try {
+    while (true) {
+      yield put(syncItem(itemId));
+      yield call(delay, interval);
+    }
+  } catch (error) {
+    if (error instanceof SagaCancellationException) {
+      yield put({ type: SYNC_STOPPED, payload: { itemId } });
+    } else {
+      yield put({ type: SYNC_STOPPED, payload: { itemId, error }, error: true });
+    }
+  }
+}
+
+export function* syncSaga() {
+  // Wait for the first sync start and then run the task in the background
+  let lastStartSync = yield take(SYNC_START);
+  let bgSyncTask = yield fork(itemSyncTask, lastStartSync.payload.itemId, lastStartSync.payload.interval);
+
+  // checks if the action is a stop or a start for a different itemId
+  const checkNewAction = action => {
+    if (action.type === SYNC_STOP) {
+      return true;
+    } else if (action.type === SYNC_START &&
+               action.payload.itemId !== lastStartSync.payload.itemId) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
+  while (true) {
+    // wait for the user stop action or start a different sync
+    const nextAction = yield take(checkNewAction);
+
+    // this will throw a SagaCancellationException into task
+    yield cancel(bgSyncTask);
+
+    // if new start then use that for the next sync job
+    if (nextAction.type === SYNC_START) {
+      lastStartSync = nextAction;
+    // otherwise wait for the next start
+    } else {
+      lastStartSync = yield take(SYNC_START);
+    }
+    // starts the new task in the background
+    bgSyncTask = yield fork(itemSyncTask, lastStartSync.payload.itemId, lastStartSync.payload.interval);
+  }
+}

--- a/examples/tasks/test/task-spec.js
+++ b/examples/tasks/test/task-spec.js
@@ -80,7 +80,7 @@ test('fully running', t => {
     .then(() => store.dispatch({ type: CANCEL_SAGA }));
   }, 10);
 
-  const task = runSaga(cancellableSaga(syncSaga()), storeIO(store));
+  const task = runSaga(cancellableSaga(syncSaga), storeIO(store));
 
   const expectedResults = [
     stopSyncing(),

--- a/examples/tasks/test/task-spec.js
+++ b/examples/tasks/test/task-spec.js
@@ -1,0 +1,106 @@
+import test from 'tape';
+import { take, fork, runSaga, storeIO, cancel } from '../../../src';
+import { createStore, applyMiddleware, compose } from 'redux';
+
+import { SYNC_START, SYNC_STOPPED, startSyncing, stopSyncing, syncItem } from '../actions.js';
+import { itemSyncTask, syncSaga } from '../taskSagas';
+
+// Describe the behavior of the saga, dont run it
+test('behavior spec', t => {
+  t.plan(2)
+  const generator = syncSaga()
+
+  let next = generator.next()
+
+  t.deepEqual(next.value, take(SYNC_START),
+    'Waits for start'
+  )
+
+  next = generator.next(startSyncing('1'))
+  t.deepEqual(next.value, fork(itemSyncTask, '1', 5000),
+    'Starts the task sync for an item'
+  )
+
+  next = generator.next();
+  // *** How can I verify this? ***
+  // console.log(next)
+  // { value: { TAKE: [Function: checkNewAction] }, done: false }
+
+  // *** This fails because of the cancel ***
+  // next = generator.next();
+  t.end()
+});
+
+
+// Lets run it since we missed some of the functinality in the behavior test
+
+// But we can't stop the infite waiting in runSaga, lets wrap it!
+const CANCEL_SAGA = 'CANCEL_SAGA'
+
+// Wraps a saga so that it might be cancelled
+function* cancellableSaga(saga) {
+  const task = yield fork(saga);
+  yield take(CANCEL_SAGA);
+  yield cancel(task);
+}
+
+// Some test helpers
+const delay = (ms) => () => new Promise(resolve => setTimeout(resolve, ms));
+
+// Collects all the actions that were dispatched and puts them into the resultActions array
+const collectMid = resultActions => () => {
+  return next => action => {
+    resultActions.push(action);
+    next(action);
+  };
+};
+
+const createStoreWithMiddleware = resultActions => compose(
+      applyMiddleware(collectMid(resultActions))
+  )(createStore);
+
+test('fully running', t => {
+  t.plan(1)
+  const results = [];
+  const store = createStoreWithMiddleware(results)(() => {});
+
+
+  setTimeout(() => {
+    Promise.resolve(1)
+    .then(() => store.dispatch(stopSyncing())) // ignores extra stop
+    .then(delay(4))
+    .then(() => store.dispatch(startSyncing('1', 2))) // should poll twice
+    .then(delay(6))
+    .then(() => store.dispatch(startSyncing('2'))) // switch with a new start
+    .then(delay(4))
+    .then(() => store.dispatch(stopSyncing())) // can be stopped
+    .then(delay(4))
+    .then(() => store.dispatch(startSyncing('3'))) // can be restarted
+    .then(delay(4))
+    .then(() => store.dispatch({ type: CANCEL_SAGA }));
+  }, 10);
+
+  const task = runSaga(cancellableSaga(syncSaga()), storeIO(store));
+
+  const expectedResults = [
+    stopSyncing(),
+    startSyncing('1', 2),
+    syncItem('1'),
+    syncItem('1'),
+    startSyncing('2'),
+    { type: SYNC_STOPPED, payload: { itemId: '1' } },
+    syncItem('2'),
+    stopSyncing(),
+    { type: SYNC_STOPPED, payload: { itemId: '2' } },
+    startSyncing('3'),
+    syncItem('3'),
+    { type: CANCEL_SAGA }
+  ];
+
+  task.done.then(() => {
+    t.deepEqual(results, expectedResults)
+  })
+
+  task.done.catch(err => t.fail(err))
+
+});


### PR DESCRIPTION
**This does not have to be merged, just using it as a tool for discussion**

First of all, I hope its ok to "abuse" a PR like this. I thought about just making issues but I wanted to code up some of the difficulties I was facing in easy to understand examples. Also using the inline comments should be useful, and maybe it can merged as a fork/task example at some point.

Anyway...I really like redux-saga and Im trying to do some examples and get more familiar with using it (and es7 generators).

Recently I was playing around with the fork/cancel support and found it really useful for a "sync task", like a polling fetch of an item. You might want to stop the fetch at any time, or switch to polling a new item. And you shouldn't really poll more than an item at a time.

I was able to implement this somewhat easily, but ran into some snags when I began writing tests. I found it difficult to write "spec" tests for the fork/task and ended up giving up and using runSaga mainly. I've created an example for tasks that shows the gist of what I was doing and the tests. The Tests include a `***` where I thought something could be improved or I found confusing. This was also done for 0.4.1, I recently tried 0.5.0 but my tests no longer pass (regression?).

Some general thoughts:
* Export `delay` since its a common pattern - Sure its trivial but at first I tried to import it from saga and did `call(delay, 5)` which ended up just sending an undefined action. Could the input validation be improved on `call`?
* Add easy cancellation to runSaga - You'll see I rolled my own for the tests