### PR TITLE
Fix effect type value of 0 not running effect.

### DIFF
--- a/src/proc.js
+++ b/src/proc.js
@@ -91,14 +91,14 @@ export default function proc(
         is.array(effect)           ? runParallelEffect(effect, effectId)
       : is.iterator(effect)        ? proc(effect, subscribe, dispatch, monitor, effectId).done
 
-      : (data = as.take(effect))   ? runTakeEffect(data)
-      : (data = as.put(effect))    ? runPutEffect(data)
-      : (data = as.race(effect))   ? runRaceEffect(data, effectId)
-      : (data = as.call(effect))   ? runCallEffect(data, effectId)
-      : (data = as.cps(effect))    ? runCPSEffect(data)
-      : (data = as.fork(effect))   ? runForkEffect(data, effectId)
-      : (data = as.join(effect))   ? runJoinEffect(data)
-      : (data = as.cancel(effect)) ? runCancelEffect(data)
+      : (is.notUndef(data = as.take(effect)))   ? runTakeEffect(data)
+      : (is.notUndef(data = as.put(effect)))    ? runPutEffect(data)
+      : (is.notUndef(data = as.race(effect)))   ? runRaceEffect(data, effectId)
+      : (is.notUndef(data = as.call(effect)))   ? runCallEffect(data, effectId)
+      : (is.notUndef(data = as.cps(effect)))    ? runCPSEffect(data)
+      : (is.notUndef(data = as.fork(effect)))   ? runForkEffect(data, effectId)
+      : (is.notUndef(data = as.join(effect)))   ? runJoinEffect(data)
+      : (is.notUndef(data = as.cancel(effect))) ? runCancelEffect(data)
 
       : /* resolve anything else  */ Promise.resolve(effect)
     )


### PR DESCRIPTION
I was looking into writing a test case for this, but I wasn't sure where to include it. If you think it that a test is necessary for this change I wouldn't mind writing one up with a bit of guidance on where to include it. Commit message & how I stumbled on this below.

## From the commit message:

If we have an action type with an int greater than 0:

    const INCREMENT_ASYNC = 1;

This works fine. When we have an action type set to zero:

    const INCREMENT_ASYNC = 0;

The effect that we want to run will not trigger because the value
that is returned from the `as` function in `io.js` will be the number
0 which is falsey. This causes the promise ternary in `runEffect` to
always fall through to the end condition:

    Promise.resolve(effect);

Which is not what we want.

This patch fixes the issue by checking if the value returned from
the `as` function is undefined vs. relying on the truthiness of the
returned value.

## How I stumbled on it

As for a bit of background, I'm using TypeScript in a project. In TypeScript, you can use enums to define action types which is great, because it removes the need to use an interface. e.g.

```ts
export enum MATH_ACTION { AddAsync, Add, Subtract }
```

When compiled to JS, TypeScript basically assigns numbers to the values. `redux-saga` couldn't handle the `AddAsync` above (set to `0`), but the other ones worked just fine.