### PR TITLE
yield [] should return immediately an empty array instead of blocking…

### DIFF
--- a/src/proc.js
+++ b/src/proc.js
@@ -308,6 +308,13 @@ export default function proc(
     let completed
     const results = Array(effects.length)
 
+    function checkEffectEnd() {
+      if(completedCount === results.length) {
+        completed = true
+        cb(null, results)
+      }
+    }
+
     const childCbs = effects.map( (eff, idx) => {
         const chCbAtIdx = (err, res) => {
           // Either we've  been cancelled, or an error aborted the whole effect
@@ -329,15 +336,14 @@ export default function proc(
           } else {
             results[idx] = res
             completedCount++
-            if(completedCount === results.length) {
-              completed = true
-              cb(null, results)
-            }
+            checkEffectEnd()
           }
         }
         chCbAtIdx.cancel = noop
         return chCbAtIdx
     })
+
+    checkEffectEnd()
 
     // This is different, a cancellation coming from upward
     // either a MANUAL_CANCEL or a parent AUTO_CANCEL

--- a/test/proc/parallel.js
+++ b/test/proc/parallel.js
@@ -45,6 +45,32 @@ test('processor array of effects handling', assert => {
 
 });
 
+test('processor empty array', assert => {
+  assert.plan(1);
+
+  let actual;
+
+  const input = cb => {
+    return () => {}
+  }
+
+  function* genFn() {
+    actual = yield []
+  }
+
+  proc(genFn(), input).done.catch(err => assert.fail(err))
+
+  const expected = [];
+
+  setTimeout(() => {
+    assert.deepEqual(actual, expected,
+      "processor must fullfill parallel effects"
+    );
+    assert.end();
+  }, DELAY)
+
+});
+
 test('processor array of effect: handling errors', assert => {
   assert.plan(1);
 


### PR DESCRIPTION
… forever, like Promise.all([]) did



@yelouafi I encountered a bug while trying to replace:

```javascript
function* cancelAll(tasks) {
  try {
    yield tasks.map(cancel)
  }
  catch(err) { void(0); }
}

let subtasks = [];
yield fork(cancelAll,subtasks);
````

by:

```javascript
let subtasks = [];
yield subtasks.map(cancel);
```


It seems your new promiseless implementation does not handle empty arrays and this PR seems to solve the issue