### PR TITLE
Better error printing in non-browser environments (node.js)

### DIFF
--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -73,8 +73,8 @@ export default function proc(
   )
 
   /**
-    this maybe called by a parent generator to trigger/propagate cancellation
-    W'll simply cancel the current effect, which will reject that effect
+    This may be called by a parent generator to trigger/propagate cancellation
+    We'll simply cancel the current effect, which will reject that effect
     The rejection will throw the injected SagaCancellationException into the flow
     of this generator
   **/
@@ -99,13 +99,13 @@ export default function proc(
     until the generator terminates or throws
   **/
   function next(error, arg) {
-    // Preventive measure. If we endup here, then there is really something wrong
+    // Preventive measure. If we end up here, then there is really something wrong
     if(!iterator._isRunning)
       throw new Error('Trying to resume an already finished generator')
 
 
     try {
-      // calling iterator.throw on a generator that doesnt defined a correponding try/Catch
+      // calling iterator.throw on a generator that doesn't define a correponding try/Catch
       // will throw an exception and jump to the catch block below
       const result = error ? iterator.throw(error) : iterator.next(arg)
       if(!result.done) {
@@ -362,7 +362,7 @@ export default function proc(
 
     const childCbs = effects.map( (eff, idx) => {
         const chCbAtIdx = (err, res) => {
-          // Either we've  been cancelled, or an error aborted the whole effect
+          // Either we've been cancelled, or an error aborted the whole effect
           if(completed)
             return
           // one of the effects failed

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -95,7 +95,7 @@ export default function proc(
 
   /**
     This is the generator driver
-    It's a recursive aysnc/continuation function which calls itself
+    It's a recursive async/continuation function which calls itself
     until the generator terminates or throws
   **/
   function next(error, arg) {

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -94,6 +94,19 @@ export default function proc(
   return task
 
   /**
+    Print error in a useful way whether in a browser environment
+    (with expandable error stack traces), or in a node.js environment
+    (text-only log output)
+   **/
+  function logError(level, message, error) {
+    if (typeof window === 'undefined') {
+      console.log(`redux-saga ${level}: ${message}\n${error.stack}`)
+    } else {
+      console[level].call(console, message, error)
+    }
+  }
+
+  /**
     This is the generator driver
     It's a recursive async/continuation function which calls itself
     until the generator terminates or throws
@@ -118,10 +131,11 @@ export default function proc(
 
       /*eslint-disable no-console*/
       if(error instanceof SagaCancellationException) {
-        if(isDev)
-          console.warn(`${name}: uncaught`, error )
+        if(isDev) {
+          logError('warn', `${name}: uncaught`, error)
+        }
       } else {
-        console.error(`${name}: uncaught`, error )
+        logError('error', `${name}: uncaught`, error)
         //if(!forked)
         //  throw error
       }


### PR DESCRIPTION
I'm using redux-saga in an Electron app and most of my sagas run node-side.

In node.js, error objects passed to `console.warn` or `console.error` just print the error's prototype name and message, not the trace:

![stack-trace](https://cloud.githubusercontent.com/assets/7998310/13814544/f5e76856-eb86-11e5-941e-b37b64164383.png)

I changed it to manually print the trace, if one is available:

![sample-error](https://cloud.githubusercontent.com/assets/7998310/13814590/26ea7f60-eb87-11e5-8b5c-08e859ac34e9.png)

It could be improved even more by tracking the whole saga chain so we know how we ended up there, but that's already a big step up :)