### PR TITLE
Added "jsnext:main" entry to package.json for ES2015 module import.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.4",
   "description": "Saga middleware for Redux to handle Side Effects",
   "main": "lib/index.js",
+  "jsnext:main": "src/index.js",
   "scripts": {
     "lint": "eslint src",
     "test": "babel-node test/index.js | tap-spec",

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,4 +1,3 @@
-
 import { take, put, race, call, apply, cps, fork, join, cancel, select } from './internal/io'
 
-module.exports = { take, put, race, call, apply, cps, fork, join, cancel, select }
+export { take, put, race, call, apply, cps, fork, join, cancel, select }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,3 @@
-
 import {
   TASK,
   noop,
@@ -21,8 +20,7 @@ import { createMockTask } from './internal/testUtils'
 
 import * as monitorActions from './internal/monitorActions'
 
-
-module.exports = {
+export {
   TASK,
   noop,
   is, asEffect,


### PR DESCRIPTION
What do you think of rollup's proposal for supporting ES2015 module imports: [https://github.com/rollup/rollup/wiki/jsnext:main](url) ?

I've only been using rollup (instead of webpack) on a new project for a couple of days and haven't formed an opinion yet, but this small addition of a "jsnext:main" entry to package.json supports directly importing redux-saga's ES2015 source with rollup's "tree shaking" code elimination, and without needing an additional rollup commonjs plugin.