### PR TITLE
Docs typo

### DIFF
--- a/docs/advanced/UsingRunSaga.md
+++ b/docs/advanced/UsingRunSaga.md
@@ -16,7 +16,7 @@ function* saga() { ... }
 
 const myIO = {
   subscribe: ..., // this will be used to resolve take Effects
-  dispatch: ...,  // this will be used to resolvce put Effects
+  dispatch: ...,  // this will be used to resolve put Effects
   getState: ...,  // this will be used to resolve select Effects
 }
 


### PR DESCRIPTION
Fixes a typo in [UsingRunSaga](http://yelouafi.github.io/redux-saga/docs/advanced/UsingRunSaga.html)