### PR TITLE
Only check eventChannel matcher if defined

### DIFF
--- a/src/internal/channel.js
+++ b/src/internal/channel.js
@@ -113,7 +113,7 @@ export function channel(buffer) {
 }
 
 export function eventChannel(subscribe, buffer = buffers.none(), matcher) {
-  if(arguments.length > 1)
+  if(typeof matcher !== 'undefined')
     check(matcher, is.func, 'Invalid match function passed to eventChannel')
 
   const chan = channel(buffer)


### PR DESCRIPTION
The `eventChannel` function was enforcing the matcher function when passed 2 arguments, even though the function supports no matcher in any case.