### PR TITLE
Clean up docs style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,39 @@
 # redux-saga
 
-[![Join the chat at https://gitter.im/yelouafi/redux-saga](https://badges.gitter.im/yelouafi/redux-saga.svg)](https://gitter.im/yelouafi/redux-saga?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
- [![npm version](https://img.shields.io/npm/v/redux-saga.svg?style=flat-square)](https://www.npmjs.com/package/redux-saga)
+[![Join the chat at https://gitter.im/yelouafi/redux-saga](https://badges.gitter.im/yelouafi/redux-saga.svg)](https://gitter.im/yelouafi/redux-saga?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![npm version](https://img.shields.io/npm/v/redux-saga.svg?style=flat-square)](https://www.npmjs.com/package/redux-saga)
 
-An alternative Side Effects middleware (aka Asynchronous Actions) for Redux applications.
-Instead of dispatching Thunks which get handled by the `redux-thunk` middleware, you
-create *Sagas* to gather all your Side Effects logic in a central place.
+An alternative Side Effects middleware (aka Asynchronous Actions) for Redux applications. Instead of dispatching Thunks which get handled by the `redux-thunk` middleware, you create *Sagas* to gather all your Side Effects logic in a central place.
 
 This means application logic lives in 2 places:
 
 - Reducers are responsible for handling state transitions between actions.
-
 - Sagas are responsible for orchestrating complex/asynchronous operations.
 
-Sagas are created using Generator functions. If you're not familiar with them you may find
-[some useful links here.](http://yelouafi.github.io/redux-saga/docs/ExternalResources.html)
+Sagas are created using Generator functions. If you're not familiar with them you may find [some useful links here.](http://yelouafi.github.io/redux-saga/docs/ExternalResources.html)
 
-Unlike Thunks which get invoked on every action by Action Creators, Sagas are fired only
-once at the start of the application (but startup Sagas may fire other Sagas dynamically).
-They can be seen as Processes running in the background. Sagas watch the actions dispatched
-to the Store, then decide what to do based on dispatched actions: Either making an asynchronous
-call (like an AJAX request), dispatching other actions to the Store, or even starting other
-Sagas dynamically.
+Unlike Thunks which get invoked on every action by Action Creators, Sagas are fired only once at the start of the application (but startup Sagas may fire other Sagas dynamically). They can be seen as Processes running in the background. Sagas watch the actions dispatched to the Store, then decide what to do based on dispatched actions: Either making an asynchronous call (like an AJAX request), dispatching other actions to the Store, or even starting other Sagas dynamically.
 
-In `redux-saga` all the above tasks are achieved by yielding **Effects**. Effects are simply
-JavaScript Objects containing instructions to be executed by the Saga middleware (As an analogy,
-you can see Redux actions as Objects containing instructions to be executed by the Store).
-`redux-saga` provides Effect creators for various tasks like calling an asynchronous function,
-dispatching an action to the Store, starting a background task or waiting for a future action
-that satisfies a certain condition.
+In `redux-saga` all the above tasks are achieved by yielding **Effects**. Effects are simply JavaScript Objects containing instructions to be executed by the Saga middleware (As an analogy, you can see Redux actions as Objects containing instructions to be executed by the Store). `redux-saga` provides Effect creators for various tasks like calling an asynchronous function, dispatching an action to the Store, starting a background task or waiting for a future action that satisfies a certain condition.
 
-Using Generators, `redux-saga` allows you to write your asynchronous code in a simple
-synchronous style. Just like you can do with `async/await` functions. But Generators
-allow some things that aren't possible with `async` functions.
+Using Generators, `redux-saga` allows you to write your asynchronous code in a simple synchronous style. Just like you can do with `async/await` functions. But Generators allow some things that aren't possible with `async` functions.
 
-The fact that Sagas yield plain Objects makes it easy to test all the logic inside your Generator
-by simply iterating over the yielded Objects and doing simple equality tests.
+The fact that Sagas yield plain Objects makes it easy to test all the logic inside your Generator by simply iterating over the yielded Objects and doing simple equality tests.
 
-Furthermore, tasks started in `redux-saga` can be cancelled at any moment either manually
-or automatically by putting them in a race with other Effects.
+Furthermore, tasks started in `redux-saga` can be cancelled at any moment either manually or automatically by putting them in a race with other Effects.
 
 # Getting started
 
 ## Install
 
-```
-npm install --save redux-saga
+```sh
+$ npm install --save redux-saga
 ```
 
-Alternatively, you may use the provided UMD builds directly in the `<script>` tag of
-an HTML page. See [this section.](#using-umd-build-in-the-browser)
+Alternatively, you may use the provided UMD builds directly in the `<script>` tag of an HTML page. See [this section](#using-umd-build-in-the-browser).
 
 ## Usage Example
 
-Suppose we have an UI to fetch some user data from a remote server when a button is clicked
-(For brevity, we'll just show the action triggering code).
+Suppose we have an UI to fetch some user data from a remote server when a button is clicked. (For brevity, we'll just show the action triggering code.)
 
 ```javascript
 class UserComponent extends React.Component {
@@ -67,17 +46,16 @@ class UserComponent extends React.Component {
 }
 ```
 
-The Component dispatches a plain Object action to the Store. We'll create a Saga that
-watches for all `USER_FETCH_REQUESTED` actions and triggers an API call to fetch the
-user data.
+The Component dispatches a plain Object action to the Store. We'll create a Saga that watches for all `USER_FETCH_REQUESTED` actions and triggers an API call to fetch the user data.
 
 #### `sagas.js`
+
 ```javascript
 import { takeEvery, takeLatest } from 'redux-saga'
 import { call, put } from 'redux-saga/effects'
 import Api from '...'
 
-// worker Saga : will be fired on USER_FETCH_REQUESTED actions
+// worker Saga: will be fired on USER_FETCH_REQUESTED actions
 function* fetchUser(action) {
    try {
       const user = yield call(Api.fetchUser, action.payload.userId);
@@ -88,19 +66,19 @@ function* fetchUser(action) {
 }
 
 /*
-  starts fetchUser on each dispatched `USER_FETCH_REQUESTED` action
-  Allow concurrent fetches of user
+  Starts fetchUser on each dispatched `USER_FETCH_REQUESTED` action.
+  Allows concurrent fetches of user.
 */
 function* mySaga() {
   yield* takeEvery("USER_FETCH_REQUESTED", fetchUser);
 }
 
 /*
-  Alternatively you may use takeLatest
+  Alternatively you may use takeLatest.
 
-  Do not allow concurrent fetches of user, If "USER_FETCH_REQUESTED" gets
+  Does not allow concurrent fetches of user. If "USER_FETCH_REQUESTED" gets
   dispatched while a fetch is already pending, that pending fetch is cancelled
-  and only the latest one will be run
+  and only the latest one will be run.
 */
 function* mySaga() {
   yield* takeLatest("USER_FETCH_REQUESTED", fetchUser);
@@ -110,6 +88,7 @@ function* mySaga() {
 To run our Saga, we'll have to connect it to the Redux Store using the `redux-saga` middleware.
 
 #### `main.js`
+
 ```javascript
 import { createStore, applyMiddleware } from 'redux'
 import createSagaMiddleware from 'redux-saga'
@@ -144,8 +123,7 @@ sagaMiddleware.run(mySaga)
 
 # Using umd build in the browser
 
-There's also an **umd** build of `redux-saga` available in the `dist/` folder. When using the umd build
-`redux-saga` is available as `ReduxSaga` in the window object.
+There is also a **umd** build of `redux-saga` available in the `dist/` folder. When using the umd build `redux-saga` is available as `ReduxSaga` in the window object.
 
 The umd version is useful if you don't use Webpack or Browserify. You can access it directly from [npmcdn](npmcdn.com).
 
@@ -154,10 +132,7 @@ The following builds are available:
 - [https://npmcdn.com/redux-saga/dist/redux-saga.js](https://npmcdn.com/redux-saga/dist/redux-saga.js)  
 - [https://npmcdn.com/redux-saga/dist/redux-saga.min.js](https://npmcdn.com/redux-saga/dist/redux-saga.min.js)
 
-**Important!** If the browser you are targeting doesn't support _es2015 generators_ you must provide a valid polyfill,
-for example the one provided by *babel*:
-[browser-polyfill.min.js](https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.25/browser-polyfill.min.js).
-The polyfill must be imported before **redux-saga**.
+**Important!** If the browser you are targeting doesn't support *ES2015 generators*, you must provide a valid polyfill, such as [the one provided by `babel`](https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.25/browser-polyfill.min.js). The polyfill must be imported before **redux-saga**:
 
 ```javascript
 import 'babel-polyfill'
@@ -167,69 +142,67 @@ import sagaMiddleware from 'redux-saga'
 
 # Building examples from sources
 
-```
-git clone https://github.com/yelouafi/redux-saga.git
-cd redux-saga
-npm install
-npm test
+```sh
+$ git clone https://github.com/yelouafi/redux-saga.git
+$ cd redux-saga
+$ npm install
+$ npm test
 ```
 
 Below are the examples ported (so far) from the Redux repos.
 
 ### Counter examples
 
-There are 3 counter examples.
+There are three counter examples.
 
 #### counter-vanilla
 
-Demo using vanilla JavaScript and UMD builds. All source is inlined in `index.html`
+Demo using vanilla JavaScript and UMD builds. All source is inlined in `index.html`.
 
 To launch the example, just open `index.html` in your browser.
 
->Important
-Your browser must support Generators. Latest versions of Chrome/Firefox/Edge are suitable.
-
+> Important: your browser must support Generators. Latest versions of Chrome/Firefox/Edge are suitable.
 
 #### counter
 
-Demo using webpack and high level API `takeEvery`
+Demo using `webpack` and high-level API `takeEvery`.
 
-```
-npm run counter
+```sh
+$ npm run counter
 
-// test sample for the generator
-npm run test-counter
+# test sample for the generator
+$ npm run test-counter
 ```
 
 #### cancellable-counter
 
-Demo using low level API. Demonstrate task cancellation.
+Demo using low-level API to demonstrate task cancellation.
 
-```
-npm run cancellable-counter
+```sh
+$ npm run cancellable-counter
 ```
 
 ### Shopping Cart example
 
-```
-npm run shop
+```sh
+$ npm run shop
 
-// test sample for the generator
-npm run test-shop
+# test sample for the generator
+$ npm run test-shop
 ```
 
 ### async example
 
-```
-npm run async
+```sh
+$ npm run async
 
-//sorry, no tests yet
+# sorry, no tests yet
 ```
 
 ### real-world example (with webpack hot reloading)
 
-```
-npm run real-world
+```sh
+$ npm run real-world
 
-//sorry, no tests yet
+# sorry, no tests yet
 ```

--- a/docs/ExternalResources.md
+++ b/docs/ExternalResources.md
@@ -2,20 +2,15 @@
 
 ### Articles on Generators
 
-- [The Basics Of ES6 Generators](https://davidwalsh.name/es6-generators) By Kyle Simpson
-- [ES6 generators in depth](http://www.2ality.com/2015/03/es6-generators.html) By Axel Rauschmayer
+- [The Basics Of ES6 Generators](https://davidwalsh.name/es6-generators) by Kyle Simpson
+- [ES6 generators in depth](http://www.2ality.com/2015/03/es6-generators.html) by Axel Rauschmayer
 
 ### Articles on redux-saga
 
-- [Redux nowadays : From actions creators to sagas](http://riadbenguella.com/from-actions-creators-to-sagas-redux-upgraded/)
-By Riad Benguella
-- [Managing Side Effects In React + Redux Using Sagas](http://jaysoo.ca/2016/01/03/managing-processes-in-redux-using-sagas/)
-By Jack Hsu
-- [Using redux-saga To Simplify Your Growing React Native Codebase](https://medium.com/infinite-red/using-redux-saga-to-simplify-your-growing-react-native-codebase-2b8036f650de#.7wl4wr1tk)
-By Steve Kellock
-- [Master Complex Redux Workflows with Sagas](http://konkle.us/master-complex-redux-workflows-with-sagas/)
-By Brandon Konkle
-- [Handling async in Redux with Sagas](http://wecodetheweb.com/2016/01/23/handling-async-in-redux-with-sagas/)
-By Niels Gerritsen
-- [Tips to handle Authentication in Redux](https://medium.com/@MattiaManzati/tips-to-handle-authentication-in-redux-2-introducing-redux-saga-130d6872fbe7#.g49x2gj1g) By Mattia Manzati
-- [Build an Image Gallery Using React, Redux and redux-saga](http://joelhooks.com/blog/2016/03/20/build-an-image-gallery-using-redux-saga/?utm_content=bufferbadc3&utm_medium=social&utm_source=twitter.com&utm_campaign=buffer) By Joel Hooks
+- [Redux nowadays: From actions creators to sagas](http://riadbenguella.com/from-actions-creators-to-sagas-redux-upgraded/) by Riad Benguella
+- [Managing Side Effects In React + Redux Using Sagas](http://jaysoo.ca/2016/01/03/managing-processes-in-redux-using-sagas/) by Jack Hsu
+- [Using redux-saga To Simplify Your Growing React Native Codebase](https://medium.com/infinite-red/using-redux-saga-to-simplify-your-growing-react-native-codebase-2b8036f650de#.7wl4wr1tk) by Steve Kellock
+- [Master Complex Redux Workflows with Sagas](http://konkle.us/master-complex-redux-workflows-with-sagas/) by Brandon Konkle
+- [Handling async in Redux with Sagas](http://wecodetheweb.com/2016/01/23/handling-async-in-redux-with-sagas/) by Niels Gerritsen
+- [Tips to handle Authentication in Redux](https://medium.com/@MattiaManzati/tips-to-handle-authentication-in-redux-2-introducing-redux-saga-130d6872fbe7#.g49x2gj1g) by Mattia Manzati
+- [Build an Image Gallery Using React, Redux and redux-saga](http://joelhooks.com/blog/2016/03/20/build-an-image-gallery-using-redux-saga/?utm_content=bufferbadc3&utm_medium=social&utm_source=twitter.com&utm_campaign=buffer) by Joel Hooks

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -38,7 +38,7 @@ function* saga() {
   yield call(ApiFn, ...args)      // Blocking: will wait for ApiFn (If ApiFn returns a Promise)
   yield call(otherSaga, ...args)  // Blocking: will wait for otherSaga to terminate
 
-  yied put(...)                   // Blocking: will dispatch asynchronously (using Promis.then)
+  yield put(...)                   // Blocking: will dispatch asynchronously (using Promise.then)
 
   const task = yield fork(otherSaga, ...args)  // Non-blocking: will not wait for otherSaga
   yield cancel(task)                           // Non-blocking: will resume immediately
@@ -59,7 +59,7 @@ example
 
 ```javascript
 function* watcher() {
-  while(true) {
+  while (true) {
     const action = yield take(ACTION)
     yield fork(worker, action.paylaod)
   }

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -64,7 +64,7 @@ function* mySaga() {
 generator will delegate all its `next()` calls to the returned iterator. This means any call to
 `next()` of `mySaga` will forward to `next()` of the `takeEvery(...)` iterator. And only after the
 the `takeEvery(...)` iterator is done, the call to the second `yield* takeEvery(ACTION_2, doSomeWork)`
-will proceed (since `takeEvery(...)` is executing a `while(true) {...}` under the hoods. The
+will proceed (since `takeEvery(...)` is executing a `while (true) {...}` under the hoods. The
 first iterator will never terminate so the second call will never proceed).
 
 With the parallel form `yield [takeEvery(...), ...]` The middleware will run all the returned
@@ -79,7 +79,7 @@ For example, consider this example
 
 ```javascript
 function watchRequestActions() {
-  while(true) {
+  while (true) {
     const {url, params} = yield take('REQUEST')
     yield call(handleRequestAction, url, params) // The Saga will block here
   }
@@ -116,7 +116,7 @@ To avoid blocking the Saga, you can use a **non-blocking call** using `fork` ins
 
 ```javascript
 function watchRequestActions() {
-  while(true) {
+  while (true) {
     const {url, params} = yield take('REQUEST')
     yield fork(handleRequestAction, url, params) // The Saga will resume immediately
   }

--- a/docs/advanced/Channels.md
+++ b/docs/advanced/Channels.md
@@ -1,50 +1,40 @@
-## Using channels
+# Using Channels
 
-Until now We've used the `take` and `put` effects to communicate with the Redux Store. Channels
-generalize those Effects to communicate with external event sources or between Sagas themselves. They can
-also be used to  queue specific actions from the Store.
+Until now We've used the `take` and `put` effects to communicate with the Redux Store. Channels generalize those Effects to communicate with external event sources or between Sagas themselves. They can also be used to queue specific actions from the Store.
 
-In this section We'll see
+In this section, we'll see:
 
 - How to use the `yield actionChannel` Effect to buffer specific actions from the Store.
 
-- How to use the `eventChannel` factory function to connect `take` Effects to external event sources
+- How to use the `eventChannel` factory function to connect `take` Effects to external event sources.
 
-- How to Create a channel using the generic `channel` factory function and use it in `take`/`put` Effects to
-communicate between 2 Sagas
+- How to create a channel using the generic `channel` factory function and use it in `take`/`put` Effects to
+communicate between two Sagas.
 
+## Using the `actionChannel` Effect
 
-### Using the `actionChannel` Effect
-
-Let's review the canonical example
+Let's review the canonical example:
 
 ```javascript
 import { take, fork, ... } from 'redux-saga/effects'
 
 function* watchRequests() {
-  while(true) {
+  while (true) {
     const {payload} = yield take('REQUEST')
     yield fork(handleRequest)
   }
 }
 
 function* handleRequest(payload) { ... }
-
 ```
 
-The above example illustrates the typical *watch-and-fork* pattern. The `watchRequests` saga is using `fork` to avoid
-non blocking and thus not missing any action from the store. A `handleRequest` task is created on each `REQUEST`
-action. So if there are many actions fired at a rapid race there can be many `handleRequest` tasks executing on parallel.
+The above example illustrates the typical *watch-and-fork* pattern. The `watchRequests` saga is using `fork` to avoid non-blocking and thus not missing any action from the store. A `handleRequest` task is created on each `REQUEST` action. So if there are many actions fired at a rapid race there can be many `handleRequest` tasks executing on parallel.
 
-Imagine now that our requirement is as follow: we want to process `REQUEST` only one by one. Meaning if we have at a moment
-say four actions, we want to handle the 1st `REQUEST` action, then only after finishing processing the action we process
-the 2nd action on so on...
+Imagine now that our requirement is as follow: we want to process `REQUEST` only one by one. Meaning if we have at a moment say four actions, we want to handle the 1st `REQUEST` action, then only after finishing processing the action we process the 2nd action on so on...
 
-So what we want is to *queue* all non processed actions, and once we're done with processing the current request, we get the
-next message from the queue.
+So what we want is to *queue* all non processed actions, and once we're done with processing the current request, we get the next message from the queue.
 
-The library provides a little helper Effect `actionChannel` which can handle this stuff for us. Let's see how we can rewrite the
-previous example with it
+The library provides a little helper Effect `actionChannel` which can handle this stuff for us. Let's see how we can rewrite the previous example with it:
 
 ```javascript
 import { take, actionChannel, call, ... } from 'redux-saga/effects'
@@ -52,7 +42,7 @@ import { take, actionChannel, call, ... } from 'redux-saga/effects'
 function* watchRequests() {
   // 1- Create a channel for request actions
   const requestChan = yield actionChannel('REQUEST')
-  while(true) {
+  while (true) {
     // 2- take from the channel
     const {payload} = yield take(requestChan)
     // 3- Note that we're using a blocking call
@@ -61,26 +51,17 @@ function* watchRequests() {
 }
 
 function* handleRequest(payload) { ... }
-
 ```
 
-The first thing is to create the action channel. We use `yield actionChannel(pattern)` where pattern is interpreted using
-the same rules we mentioned previously with `take(pattern)`. The difference between the 2 forms is that `actionChannel` **can
-buffer incoming messages** if the Saga if not yet ready to take them (e.g. blocked on an API call).
+The first thing is to create the action channel. We use `yield actionChannel(pattern)` where pattern is interpreted using the same rules we mentioned previously with `take(pattern)`. The difference between the 2 forms is that `actionChannel` **can buffer incoming messages** if the Saga if not yet ready to take them (e.g. blocked on an API call).
 
-Next thing is the `yield take(requestChan)`. Besides usage with a `pattern` to take specific actions from the Redux Store, `take`
-can also be used with channels (above we created a channel object from specific Redux actions). The `take` will block the Saga until
-a message is available on the channel. The take may also resume immediately if there is a message stored in the underlying buffer.
+Next thing is the `yield take(requestChan)`. Besides usage with a `pattern` to take specific actions from the Redux Store, `take` can also be used with channels (above we created a channel object from specific Redux actions). The `take` will block the Saga until a message is available on the channel. The take may also resume immediately if there is a message stored in the underlying buffer.
 
-The important thing to note is how we're using a blocking `call`. The Saga will remain blocked until `call(handleRequest)` returns. But
-meanwhile, if other `REQUEST` actions are dispatched while the Saga is still blocked, they will queued internally by `requestChan`. When
-the Saga resumes from `call(handleRequest)` and executes the next `yield take(requestChan)`, the take will resolve with the queued message.
+The important thing to note is how we're using a blocking `call`. The Saga will remain blocked until `call(handleRequest)` returns. But meanwhile, if other `REQUEST` actions are dispatched while the Saga is still blocked, they will queued internally by `requestChan`. When the Saga resumes from `call(handleRequest)` and executes the next `yield take(requestChan)`, the take will resolve with the queued message.
 
-By default, `actionChannel` buffers all incoming messages without limit. If you want a more control over the buffering, you can supply a Buffer
-argument to the effect creator. The library provides some common buffers (none, dropping, sliding) but you can also supply your own
-buffer implementation. See API docs for more details.
+By default, `actionChannel` buffers all incoming messages without limit. If you want a more control over the buffering, you can supply a Buffer argument to the effect creator. The library provides some common buffers (none, dropping, sliding) but you can also supply your own buffer implementation. See API docs for more details.
 
-For example if you want to handle only the most recent five (5) items you can use
+For example if you want to handle only the most recent five items you can use:
 
 ```javascript
 import { buffers } from 'redux-saga'
@@ -90,15 +71,13 @@ function* watchRequests() {
   const requestChan = yield actionChannel('REQUEST', buffers.sliding(5))
   ...
 }
-
 ```
 
-### Using the `eventChannel` factory to connect to external events
+## Using the `eventChannel` factory to connect to external events
 
-Like `actionChannel` (effect), `eventChannel` (not an effect, a factory function) creates a channel for events but from event
-sources other than the Redux Store.
+Like `actionChannel` (Effect), `eventChannel` (a factory function, not an Effect) creates a Channel for events but from event sources other than the Redux Store.
 
-This simple example creates a channel from an interval
+This simple example creates a Channel from an interval:
 
 ```javascript
 import { eventChannel, END } from 'redux-saga'
@@ -107,9 +86,9 @@ function countdown(seconds) {
   return eventChannel(listener => {
       const iv = setInterval(() => {
         secs -= 1
-        if(secs > 0)
+        if (secs > 0) {
           listener(secs)
-        else {
+        } else {
           // this causes the channel to close
           listener(END)
           clearInterval(iv)
@@ -124,12 +103,9 @@ function countdown(seconds) {
 }
 ```
 
-The first argument `eventChannel` is a *subscriber* function. The rule of the subscriber is to initialize the external event source
-(above using `setInterval`), then routes all incoming events from the source to the channel by invoking the supplied `listener`. In the
-above example we're invoking `listener` on each second.
+The first argument `eventChannel` is a *subscriber* function. The rule of the subscriber is to initialize the external event source (above using `setInterval`), then routes all incoming events from the source to the channel by invoking the supplied `listener`. In the above example we're invoking `listener` on each second.
 
-Note also the invocation `listener(END)`. We use this to notify any channel consumer that the channel has been closed, meaning no other
-message will come through this channel.
+Note also the invocation `listener(END)`. We use this to notify any channel consumer that the channel has been closed, meaning no other message will come through this channel.
 
 Let's see how we can use this channel from our Saga. This example is taken from the cancellable-counter example in the repo.
 
@@ -143,10 +119,8 @@ function countdown(seconds) { ... }
 export function* saga() {
   const chan = yield call(countdown, value)
   try {    
-    while(true) {
-      /**
-        take(END) will cause the saga to terminate by jumping to the finally block
-      **/
+    while (true) {
+      // take(END) will cause the saga to terminate by jumping to the finally block
       let seconds = yield take(chan)
       console.log(`countdown: ${seconds}`)
     }
@@ -156,18 +130,11 @@ export function* saga() {
 }
 ```
 
-So the Saga is yielding a `take(chan)`. This cause the Saga to block until a message is putted on the channel. In our
-example above, it corresponds to when we invoke `listener(secs)`. Note also we're executing the whole `while(true) {...}`
-loop inside a `try/finally` block. When the interval terminates, the countdown function closes the event channel by
-invoking `listener(END)`. Closing a channel has the effect of terminating all Sagas blocked on a `take` from that channel,
-in our example, terminating the Saga will cause it to jump to its `finally` block (if provided, otherwise the Saga simply terminate).
+So the Saga is yielding a `take(chan)`. This cause the Saga to block until a message is putted on the channel. In our example above, it corresponds to when we invoke `listener(secs)`. Note also we're executing the whole `while (true) {...}` loop inside a `try/finally` block. When the interval terminates, the countdown function closes the event channel by invoking `listener(END)`. Closing a channel has the effect of terminating all Sagas blocked on a `take` from that channel, in our example, terminating the Saga will cause it to jump to its `finally` block (if provided, otherwise the Saga simply terminate).
 
-The subscriber returns an `unsubscribe` function. This is used by the channel to unsubscribe before
-the event source complete. Inside a Saga consuming messages from an event channel, if we want to *exit early*
-before the event source complete (e.g. Saga ha been cancelled) you can call `chan.close()` to close the channel
-and unsubscribe from the source.
+The subscriber returns an `unsubscribe` function. This is used by the channel to unsubscribe before the event source complete. Inside a Saga consuming messages from an event channel, if we want to *exit early* before the event source complete (e.g. Saga ha been cancelled) you can call `chan.close()` to close the channel and unsubscribe from the source.
 
-for example, we can make our Saga support cancellation
+For example, we can make our Saga support cancellation:
 
 ```javascript
 import { take, put, call, cancelled } from 'redux-saga/effects'
@@ -179,12 +146,12 @@ function countdown(seconds) { ... }
 export function* saga() {
   const chan = yield call(countdown, value)
   try {    
-    while(true) {
+    while (true) {
       let seconds = yield take(chan)
       console.log(`countdown: ${seconds}`)
     }
   } finally {
-    if(yield cancelled()) {
+    if (yield cancelled()) {
       chan.close()
       console.log('countdown cancelled')
     }    
@@ -192,15 +159,11 @@ export function* saga() {
 }
 ```
 
-
->Note messages on an eventChannel are not buffered by default. You have to provide a buffer to the eventChannel factory in order
-to specify buffering strategy for the channel (e.g. eventChannel(subscriber, buffer). See API docs for more infos.
+> Note: messages on an eventChannel are not buffered by default. You have to provide a buffer to the eventChannel factory in order to specify buffering strategy for the channel (e.g. `eventChannel(subscriber, buffer)`). See the API docs for more info.
 
 ### Using channels to communicate between Sagas
 
-Besides actions channels and event channels. You can also directly create channels which are not connected to any
-source by default. You can then manually `put` on the channel. This is handy  when you want to use a channel to communicate
-between sagas.
+Besides actions channels and event channels. You can also directly create channels which are not connected to any source by default. You can then manually `put` on the channel. This is handy when you want to use a channel to communicate between sagas.
 
 To illustrate, let's review the former example of request handling.
 
@@ -208,22 +171,18 @@ To illustrate, let's review the former example of request handling.
 import { take, fork, ... } from 'redux-saga/effects'
 
 function* watchRequests() {
-  while(true) {
+  while (true) {
     const {payload} = yield take('REQUEST')
     yield fork(handleRequest)
   }
 }
 
 function* handleRequest(payload) { ... }
-
 ```
 
-We saw that the watch-and-fork pattern allows to handle multiple requests simultaneously, without limit on the number of worker tasks
-executing in parallel. Then we used the `actionChannel` effect to limit the concurrency to one task at a time.
+We saw that the watch-and-fork pattern allows to handle multiple requests simultaneously, without limit on the number of worker tasks executing in parallel. Then we used the `actionChannel` effect to limit the concurrency to one task at a time.
 
-So let's say that our requirement is to have a maximum of three tasks executing in the same time. When we get a request and
-there are less than 3 tasks executing, we process the request immediately, but if we have already 3 tasks executing, we queue
-the task and wait for one of the 3 *slots* to be free.
+So let's say that our requirement is to have a maximum of three tasks executing in the same time. When we get a request and there are less than three tasks executing, we process the request immediately, but if we have already three tasks executing, we queue the task and wait for one of the three *slots* to be free.
 
 Below an example of a solution using channels
 
@@ -240,7 +199,7 @@ function* watchRequests() {
     yield fork(handleRequest, chan)
   }
 
-  while(true) {
+  while (true) {
     const {payload} = yield take('REQUEST')
     yield put(chan, payload)
   }
@@ -254,15 +213,8 @@ function* handleRequest(chan) {
 }
 ```
 
-In the above example, we create a channel using the `channel` factory. We get back a channel which by default
-buffers all message we put on it (unless there is a pending taker, in which the taker is resumed immediately with
-the message).
+In the above example, we create a channel using the `channel` factory. We get back a channel which by default buffers all message we put on it (unless there is a pending taker, in which the taker is resumed immediately with the message).
 
-The `watchRequests` saga then forks three worker sagas. Note the created channel is supplied to all forked sagas.
-`watchRequests` will use this channel to *dispatch* work to the 3 worker sagas. On each `REQUEST` action the Saga
-will simply put the payload on the channel. The payload will then be taken by any *free* worker. Otherwise it'll be
-queued by the channel until a worker Saga is ready to take it.
+The `watchRequests` saga then forks three worker sagas. Note the created channel is supplied to all forked sagas. `watchRequests` will use this channel to *dispatch* work to the three worker sagas. On each `REQUEST` action the Saga will simply put the payload on the channel. The payload will then be taken by any *free* worker. Otherwise it will be queued by the channel until a worker Saga is ready to take it.
 
-All the 3 workers run a typical while loop. On each iteration, a worker will take the next request, or will block until
-a message is available. Note that this mechanism provides an automatic load-balancing between the 3 workers. Rapid workers
-are not slowed down by slow workers.
+All the three workers run a typical while loop. On each iteration, a worker will take the next request, or will block until a message is available. Note that this mechanism provides an automatic load-balancing between the 3 workers. Rapid workers are not slowed down by slow workers.

--- a/docs/advanced/ComposingSagas.md
+++ b/docs/advanced/ComposingSagas.md
@@ -2,27 +2,21 @@
 
 While using `yield*` provides an idiomatic way of composing Sagas, this approach has some limitations:
 
-- You'll likely want to test nested generators separately. This leads to some duplication in the test
-code as well as the overhead of the duplicated execution. We don't want to execute a nested generator
-but only make sure the call to it was issued with the right argument.
+- You'll likely want to test nested generators separately. This leads to some duplication in the test code as well as the overhead of the duplicated execution. We don't want to execute a nested generator but only make sure the call to it was issued with the right argument.
 
-- More importantly, `yield*` allows only for sequential composition of tasks, so you can only
-yield* to one generator at a time.
+- More importantly, `yield*` allows only for sequential composition of tasks, so you can only `yield*` to one generator at a time.
 
-You can simply use `yield` to start one or more subtasks in parallel. When yielding a call to a
-generator, the Saga will wait for the generator to terminate before progressing, then resume
-with the returned value (or throws if an error propagates from the subtask).
-
+You can simply use `yield` to start one or more subtasks in parallel. When yielding a call to a generator, the Saga will wait for the generator to terminate before progressing, then resume with the returned value (or throws if an error propagates from the subtask).
 
 ```javascript
 function* fetchPosts() {
-  yield put( actions.requestPosts() )
+  yield put(actions.requestPosts())
   const products = yield call(fetchApi, '/products')
-  yield put( actions.receivePosts(products) )
+  yield put(actions.receivePosts(products))
 }
 
 function* watchFetch() {
-  while ( yield take(FETCH_POSTS) ) {
+  while (yield take(FETCH_POSTS)) {
     yield call(fetchPosts) // waits for the fetchPosts task to terminate
   }
 }
@@ -33,32 +27,29 @@ for them to finish, then resume with all the results
 
 ```javascript
 function* mainSaga(getState) {
-  const results = yield [ call(task1), call(task2), ...]
-  yield put( showResults(results) )
+  const results = yield [call(task1), call(task2), ...]
+  yield put(showResults(results))
 }
 ```
 
-In fact, yielding Sagas is no different than yielding other effects (future actions, timeouts, etc).
-This means you can combine those Sagas with all the other types using the effect combinators.
+In fact, yielding Sagas is no different than yielding other effects (future actions, timeouts, etc). This means you can combine those Sagas with all the other types using the effect combinators.
 
-For example you may want the user to finish some game in a limited amount of time:
+For example, you may want the user to finish some game in a limited amount of time:
 
 ```javascript
 function* game(getState) {
-
   let finished
-  while(!finished) {
+  while (!finished) {
     // has to finish in 60 seconds
     const {score, timeout} = yield race({
-      score : call( play, getState),
-      timeout : call(delay, 60000)
+      score: call(play, getState),
+      timeout: call(delay, 60000)
     })
 
-    if(!timeout) {
+    if (!timeout) {
       finished = true
-      yield put( showScore(score) )
+      yield put(showScore(score))
     }
   }
-
 }
 ```

--- a/docs/advanced/Concurrency.md
+++ b/docs/advanced/Concurrency.md
@@ -1,15 +1,14 @@
-## Common Concurrency Patterns
+# Concurrency
 
-In the basics section, we saw how to use the helper functions `takeEvery` and `takeLatest`
-in order to manage Concurrency between Effects.
+In the basics section, we saw how to use the helper functions `takeEvery` and `takeLatest` in order to manage concurrency between Effects.
 
-In this section we'll see how those helpers are implemented using the low level Effects
+In this section we'll see how those helpers are implemented using the low-level Effects.
 
 ## `takeEvery`
 
 ```javascript
 function* takeEvery(pattern, saga, ...args) {
-  while(true) {
+  while (true) {
     const action = yield take(pattern)
     yield fork(saga, ...args.concat(action))
   }
@@ -23,18 +22,16 @@ function* takeEvery(pattern, saga, ...args) {
 ```javascript
 function* takeLatest(pattern, saga, ...args) {
   let lastTask
-  while(true) {
+  while (true) {
     const action = yield take(pattern)
-    if(lastTask)
+    if (lastTask) {
       yield cancel(lastTask) // cancel is no-op if the task has alerady terminated
-
+    }
     lastTask = yield fork(saga, ...args.concat(action))
   }
 }
 ```
 
-`takeLatest` doesn't allow mulitple `sagas` tasks to be fired concurrently. As soon as it
-gets a new dispatched action, it cancels any previously forked task (if it's still running).
+`takeLatest` doesn't allow multiple Saga tasks to be fired concurrently. As soon as it gets a new dispatched action, it cancels any previously-forked task (if still running).
 
-`takeLatest` can be useful to handle AJAX requests where we want to only have the response
-of the latest  request.
+`takeLatest` can be useful to handle AJAX requests where we want to only have the response to the latest request.

--- a/docs/advanced/FutureActions.md
+++ b/docs/advanced/FutureActions.md
@@ -1,21 +1,14 @@
 # Pulling future actions
 
-Until now we've used the helper function `takeEvery` in order to spawn a new task on
-each incoming action. This mimics somewhat the behavior of redux-thunk: each time a
-Component, for example, invokes a `fetchProducts` Action Creator, the Action Creator will
-dispatch a thunk to execute the control flow.
+Until now we've used the helper function `takeEvery` in order to spawn a new task on each incoming action. This mimics somewhat the behavior of redux-thunk: each time a Component, for example, invokes a `fetchProducts` Action Creator, the Action Creator will dispatch a thunk to execute the control flow.
 
-In reality, `takeEvery` is just a helper function built on top of the lower level and more
-powerful API. In this section we'll see a new Effect, `take`, which makes it possible to build complex
-control flow by allowing total control of the action observation process.
+In reality, `takeEvery` is just a helper function built on top of the lower level and more powerful API. In this section we'll see a new Effect, `take`, which makes it possible to build complex control flow by allowing total control of the action observation process.
 
 ## A simple logger
 
-Let's take a simple example of a Saga that watches all actions dispatched to the store and 
-logs them to the console.
+Let's take a simple example of a Saga that watches all actions dispatched to the store and logs them to the console.
 
-Using `takeEvery('*')` (with the wildcard `*` pattern) we can catch all dispatched actions regardless
-of their types.
+Using `takeEvery('*')` (with the wildcard `*` pattern) we can catch all dispatched actions regardless of their types.
 
 ```javascript
 import { takeEvery } from 'redux-saga'
@@ -34,7 +27,7 @@ Now let's see how to use the `take` Effect to implement the same flow as above
 import { take } from 'redux-saga/effects'
 
 function* watchAndLog(getState) {
-  while(true) {
+  while (true) {
     const action = yield take('*')
     console.log('action', action)
     console.log('state after', getState())
@@ -42,62 +35,40 @@ function* watchAndLog(getState) {
 }
 ```
 
-The `take` is just like `call` and `put` we saw earlier. It creates another command object
-that tells the middleware to wait for a specific action. The resulting behavior of the `call` Effect is the same as when the middleware suspends the Generator until a Promise resolves. In the `take`
-case it'll suspend the Generator until a matching action is dispatched. In the above example
-`watchAndLog` is suspended until any action is dispatched.
+The `take` is just like `call` and `put` we saw earlier. It creates another command object that tells the middleware to wait for a specific action. The resulting behavior of the `call` Effect is the same as when the middleware suspends the Generator until a Promise resolves. In the `take` case it'll suspend the Generator until a matching action is dispatched. In the above example `watchAndLog` is suspended until any action is dispatched.
 
-Note how we're running an endless loop `while(true)`. Remember this is a Generator function,
-which doesn't have a run-to-completion behavior. Our Generator will block on each iteration
-waiting for an action to happen.
+Note how we're running an endless loop `while (true)`. Remember this is a Generator function, which doesn't have a run-to-completion behavior. Our Generator will block on each iteration waiting for an action to happen.
 
-Using `take` has a subtle impact on how we write our code. In the case of `takeEvery` the invoked
-tasks have no control on when they'll be called. They will be invoked again and again on each matching
-action. They also have no control on when to stop the observation.
+Using `take` has a subtle impact on how we write our code. In the case of `takeEvery` the invoked tasks have no control on when they'll be called. They will be invoked again and again on each matching action. They also have no control on when to stop the observation.
 
-In the case of `take` the control is inversed. Instead of the actions being *pushed* to the
-handler tasks, the Saga is *pulling* the action by itself. It looks as if the Saga is performing
-a normal function call `action = getNextAction()` which will resolve when the action is
-dispatched.
+In the case of `take` the control is inverted. Instead of the actions being *pushed* to the handler tasks, the Saga is *pulling* the action by itself. It looks as if the Saga is performing a normal function call `action = getNextAction()` which will resolve when the action is dispatched.
 
-This inversion of control allows us to implement control flows that are non-trivial to do with
-the traditional *push* approach.
+This inversion of control allows us to implement control flows that are non-trivial to do with the traditional *push* approach.
 
-As a simple example, suppose that in our Todo application, we want to watch user actions
-and show a congratulation message when the User has created his three first Todos.
+As a simple example, suppose that in our Todo application, we want to watch user actions and show a congratulation message when the user has created his three first todos.
 
 ```javascript
 import { take, put } from 'redux-saga/effects'
 
 function* watchFirstThreeTodosCreation() {
-  for(let i = 0; i < 3; i++) {
+  for (let i = 0; i < 3; i++) {
     const action = yield take('TODO_CREATED')
   }
   yield put({type: 'SHOW_CONGRATULATION'})
 }
 ```
 
-Instead of a `while(true)` we're running a `for` loop which will iterate only three times. After
-taking the first three `TODO_CREATED` actions, `watchFirstThreeTodosCreation` will cause the
-application to display a congratulation message then terminate. This means the Generator will be
-garbage collected and no more observation will take place.
+Instead of a `while (true)` we're running a `for` loop which will iterate only three times. After taking the first three `TODO_CREATED` actions, `watchFirstThreeTodosCreation` will cause the application to display a congratulation message then terminate. This means the Generator will be garbage collected and no more observation will take place.
 
-Another benefit of the pull approach is that we can describe our control flow using a familiar
-synchronous style. For example, suppose we want to implement a login flow with 2 actions `LOGIN`
-and `LOGOUT`. Using `takeEvery` (or redux-thunk) we'll have to write 2 separate tasks (or thunks) : one for
-`LOGIN` and the other for `LOGOUT`.
+Another benefit of the pull approach is that we can describe our control flow using a familiar synchronous style. For example, suppose we want to implement a login flow with 2 actions `LOGIN` and `LOGOUT`. Using `takeEvery` (or `redux-thunk`) we'll have to write 2 separate tasks (or thunks): one for `LOGIN` and the other for `LOGOUT`.
 
-The result is that our logic is now spread in 2 places. In order for someone reading our code to
-understand what's going on, he has to read the source of the 2 handlers and make the link
-between the logic in both. It means he has to rebuild the model of the flow in his head
-by rearranging mentally the logic placed in various places of the code in the correct
-order.
+The result is that our logic is now spread in 2 places. In order for someone reading our code to understand what's going on, he has to read the source of the 2 handlers and make the link between the logic in both. It means he has to rebuild the model of the flow in his head by rearranging mentally the logic placed in various places of the code in the correct order.
 
 Using the pull model we can write our flow in the same place instead of handling the same action repeatedly.
 
 ```javascript
 function* loginFlow() {
-  while(true) {
+  while (true) {
     yield take('LOGIN')
     // ... perform the login logic
     yield take('LOGOUT')
@@ -106,6 +77,4 @@ function* loginFlow() {
 }
 ```
 
-The `loginFlow` Saga more clearly conveys the expected action sequence. It knows that the `LOGIN` action should always be followed by
-a `LOGOUT` action. And that `LOGOUT` is always followed by a `LOGIN` (a good UI should always enforce
-a consistent order of the actions, by hiding or disabling unexpected action).
+The `loginFlow` Saga more clearly conveys the expected action sequence. It knows that the `LOGIN` action should always be followed by a `LOGOUT` action and that `LOGOUT` is always followed by a `LOGIN` (a good UI should always enforce a consistent order of the actions, by hiding or disabling unexpected action).

--- a/docs/advanced/NonBlockingCalls.md
+++ b/docs/advanced/NonBlockingCalls.md
@@ -1,13 +1,12 @@
-# Non blocking calls
+# Non-blocking calls
 
-In the previous section, we saw how the `take` Effect allows us to better describe a non
-trivial flow in a central place.
+In the previous section, we saw how the `take` Effect allows us to better describe a non-trivial flow in a central place.
 
-Revisiting the login flow example
+Revisiting the login flow example:
 
 ```javascript
 function* loginFlow() {
-  while(true) {
+  while (true) {
     yield take('LOGIN')
     // ... perform the login logic
     yield take('LOGOUT')
@@ -16,22 +15,17 @@ function* loginFlow() {
 }
 ```
 
-Let's complete the example and implement the actual login/logout logic. Suppose we have
-an Api which permits us to authorize the user on a remote server. If the authorization is successful,
-the server will return an authorization token which will be stored by our application using
-DOM storage (assume our Api provides another service for DOM storage).
+Let's complete the example and implement the actual login/logout logic. Suppose we have an API which permits us to authorize the user on a remote server. If the authorization is successful, the server will return an authorization token which will be stored by our application using DOM storage (assume our API provides another service for DOM storage).
 
 When the user logs out, we'll simply delete the authorization token stored previously.
 
 ### First try
 
-So far we have all needed Effects in order to implement the above flow. We can wait for specific
-actions in the store using the `take` Effect. We can make asynchronous calls using the `call` Effect.
-Finally, we can dispatch actions to the store using the `put` Effect.
+So far we have all needed Effects in order to implement the above flow. We can wait for specific actions in the store using the `take` Effect. We can make asynchronous calls using the `call` Effect. Finally, we can dispatch actions to the store using the `put` Effect.
 
-So let's give it a try
+So let's give it a try:
 
->Note the code below has a subtle issue. Make sure to read the section until the end
+> Note: the code below has a subtle issue. Make sure to read the section until the end.
 
 ```javascript
 import { take, call, put } from 'redux-saga/effects'
@@ -48,10 +42,10 @@ function* authorize(user, password) {
 }
 
 function* loginFlow() {
-  while(true) {
+  while (true) {
     const {user, password} = yield take('LOGIN_REQUEST')
     const token = yield call(authorize, user, password)
-    if(token) {
+    if (token) {
       yield call(Api.storeItem, {token})
       yield take('LOGOUT')
       yield call(Api.clearItem, 'token')
@@ -60,56 +54,42 @@ function* loginFlow() {
 }
 ```
 
-First we created a separate Generator `authorize` which will perform the actual Api call and
-notify the Store upon success.
+First we created a separate Generator `authorize` which will perform the actual API call and notify the Store upon success.
 
-The `loginFlow` implements its entire flow inside a `while(true)` loop, which means once
-we reach the last step in the flow (`LOGOUT`) we start a new iteration by waiting for a
-new `LOGIN_REQUEST` action.
+The `loginFlow` implements its entire flow inside a `while (true)` loop, which means once we reach the last step in the flow (`LOGOUT`) we start a new iteration by waiting for a new `LOGIN_REQUEST` action.
 
-`loginFlow` first waits for a `LOGIN_REQUEST` action. Then retrieves the credentials in the
-action payload (`user` and `password`) and makes a `call` to the `authorize` task.
+`loginFlow` first waits for a `LOGIN_REQUEST` action. Then retrieves the credentials in the action payload (`user` and `password`) and makes a `call` to the `authorize` task.
 
-As you noted, `call` isn't only for invoking functions returning Promises. We can also use it to
-invoke other Generator functions. In the above example, **`loginFlow` will wait for authorize
-until it terminates and returns** (i.e. after performing the api call, dispatching the action and then
-returning the token to `loginFlow`).
+As you noted, `call` isn't only for invoking functions returning Promises. We can also use it to invoke other Generator functions. In the above example, **`loginFlow` will wait for authorize until it terminates and returns** (i.e. after performing the api call, dispatching the action and then returning the token to `loginFlow`).
 
-If the Api call succeeds, `authorize` will dispatch a `LOGIN_SUCCESS` action then return the
-fetched token. If it results in an error,  it'll dispatch a `LOGIN_ERROR` action.
+If the API call succeeds, `authorize` will dispatch a `LOGIN_SUCCESS` action then return the fetched token. If it results in an error,  it'll dispatch a `LOGIN_ERROR` action.
 
-If the call to `authorize` is successful, `loginFlow` will store the returned token
-in the DOM storage and wait for a `LOGOUT` action. When the user logouts, we remove the
-stored token and wait for a new user login.
+If the call to `authorize` is successful, `loginFlow` will store the returned token in the DOM storage and wait for a `LOGOUT` action. When the user logouts, we remove the stored token and wait for a new user login.
 
-In the case of `authorize` failed, it'll return an undefined value, which will cause `loginFlow`
-to skip the previous process and wait for a new `LOGIN_REQUEST` action.
+In the case of `authorize` failed, it'll return an undefined value, which will cause `loginFlow` to skip the previous process and wait for a new `LOGIN_REQUEST` action.
 
-Observe how the entire logic is stored in one place. A new developer reading our code
-doesn't have to travel between various places in order to understand the
-control flow. It's like reading a synchronous algorithm: steps are layed out in their
-natural order. And we have functions which call other functions and wait for their results.
+Observe how the entire logic is stored in one place. A new developer reading our code doesn't have to travel between various places in order to understand the control flow. It's like reading a synchronous algorithm: steps are laid out in their natural order. And we have functions which call other functions and wait for their results.
 
 ### But there is still a subtle issue with the above approach
 
-Suppose that when the `loginFlow` is waiting for the following call to resolve
+Suppose that when the `loginFlow` is waiting for the following call to resolve:
 
 ```javascript
 function* loginFlow() {
-  while(true) {
-    ...
+  while (true) {
+    // ...
     try {
       const token = yield call(authorize, user, password)
-      ...
+      // ...
     }
-    ...
+    // ...
   }
 }
 ```
 
-The user clicks on the `Logout` button causing a `LOGOUT` action to be dispatched
+The user clicks on the `Logout` button causing a `LOGOUT` action to be dispatched.
 
-The following example illustrates the hypothetical sequence of the events :
+The following example illustrates the hypothetical sequence of the events:
 
 ```
 UI                              loginFlow
@@ -123,34 +103,24 @@ LOGOUT.................................................. missed!
 ........................................................
 ```
 
-When `loginFlow` is blocked on the `authorize` call, an eventual `LOGOUT` occurring in
-between the call and the response will be missed, because `loginFlow` hasn't yet performed
-the `yield take('LOGOUT')`.
+When `loginFlow` is blocked on the `authorize` call, an eventual `LOGOUT` occurring in between the call and the response will be missed, because `loginFlow` hasn't yet performed the `yield take('LOGOUT')`.
 
-The problem with the above code is that `call` is a blocking Effect. i.e. the Generator
-can't perform/handle anything else until the call terminates. But in our case we do not only
-want `loginFlow` to execute the authorization call, but also watch for an eventual `LOGOUT`
-action that may occur in the middle of this call. That's because `LOGOUT` is *concurrent*
-to the `authorize` call.
+The problem with the above code is that `call` is a blocking Effect. i.e. the Generator can't perform/handle anything else until the call terminates. But in our case we do not only want `loginFlow` to execute the authorization call, but also watch for an eventual `LOGOUT` action that may occur in the middle of this call. That's because `LOGOUT` is *concurrent* to the `authorize` call.
 
-So what's needed is some way to start `authorize` without blocking so `loginFlow` can continue
-and watch for an eventual/concurrent `LOGOUT` action.
+So what's needed is some way to start `authorize` without blocking so `loginFlow` can continue and watch for an eventual/concurrent `LOGOUT` action.
 
-To express non-blocking calls, the library provides another Effect: [`fork`](http://yelouafi.github.io/redux-saga/docs/api/index.html#forkfn-args). When we fork
-a *task*, the task is started in the background and the caller can continue its flow without
-waiting for the forked task to terminate.
+To express non-blocking calls, the library provides another Effect: [`fork`](http://yelouafi.github.io/redux-saga/docs/api/index.html#forkfn-args). When we fork a *task*, the task is started in the background and the caller can continue its flow without waiting for the forked task to terminate.
 
-So in order for `loginFlow` to not miss a concurrent `LOGOUT`, we must not `call` the `authorize`
-task, instead we have to `fork` it.
+So in order for `loginFlow` to not miss a concurrent `LOGOUT`, we must not `call` the `authorize` task, instead we have to `fork` it.
 
 ```javascript
 import { fork, call, take, put } from 'redux-saga/effects'
 
 function* loginFlow() {
-  while(true) {
+  while (true) {
     ...
     try {
-      // non blocking call, what's the returned value here ?
+      // non-blocking call, what's the returned value here ?
       const ?? = yield fork(authorize, user, password)
       ...
     }
@@ -159,9 +129,7 @@ function* loginFlow() {
 }
 ```
 
-The issue now is since our `authorize` action is started in the background, we can't get
-the `token` result (because we'd have to wait for it). So we need to move the token storage
-operation into the `authorize` task.
+The issue now is since our `authorize` action is started in the background, we can't get the `token` result (because we'd have to wait for it). So we need to move the token storage operation into the `authorize` task.
 
 ```javascript
 import { fork, call, take, put } from 'redux-saga/effects'
@@ -177,7 +145,7 @@ function* authorize(user, password) {
 }
 
 function* loginFlow() {
-  while(true) {
+  while (true) {
     const {user, password} = yield take('LOGIN_REQUEST')
     yield fork(authorize, user, password)
     yield take(['LOGOUT', 'LOGIN_ERROR'])
@@ -186,29 +154,17 @@ function* loginFlow() {
 }
 ```
 
-We're also doing `yield take(['LOGOUT', 'LOGIN_ERROR'])`. It means we are watching for
-2 concurrent actions :
+We're also doing `yield take(['LOGOUT', 'LOGIN_ERROR'])`. It means we are watching for 2 concurrent actions:
 
-- If the `authorize` task succeeds before the user logs out, it'll dispatch a `LOGIN_SUCCESS`
-action, then terminate. Our `loginFlow` saga will then wait only for a future `LOGOUT` action
-(because `LOGIN_ERROR` will never happen).
+- If the `authorize` task succeeds before the user logs out, it'll dispatch a `LOGIN_SUCCESS` action, then terminate. Our `loginFlow` saga will then wait only for a future `LOGOUT` action (because `LOGIN_ERROR` will never happen).
 
-- If the `authorize` fails before the user logs out, it'll dispatch a `LOGIN_ERROR` action, then
-terminate. So `loginFlow` will take the `LOGIN_ERROR` before the `LOGOUT` then it'll enter in
-a another `while` iteration and will wait for the next `LOGIN_REQUEST` action.
+- If the `authorize` fails before the user logs out, it will dispatch a `LOGIN_ERROR` action, then terminate. So `loginFlow` will take the `LOGIN_ERROR` before the `LOGOUT` then it will enter in a another `while` iteration and will wait for the next `LOGIN_REQUEST` action.
 
-- If the user logs out before the `authorize` terminate, then `loginFlow` will take a `LOGOUT`
-action and also wait for the next `LOGIN_REQUEST`.
+- If the user logs out before the `authorize` terminate, then `loginFlow` will take a `LOGOUT` action and also wait for the next `LOGIN_REQUEST`.
 
-Note the call for `Api.clearItem` is supposed to be idempotent. It'll have no effect if no token was
-stored by the `authorize` call. `loginFlow` makes sure no token will be in the storage
-before waiting for the next login.
+Note the call for `Api.clearItem` is supposed to be idempotent. It'll have no effect if no token was stored by the `authorize` call. `loginFlow` makes sure no token will be in the storage before waiting for the next login.
 
-But we're not yet done. If we take a `LOGOUT` in the middle of an Api call, we have
-to **cancel** the `authorize` process, otherwise we'll have 2 concurrent tasks evolving in
-parallel: The `authorize` task will continue running and upon a successful (resp. failed)
-result, will dispatch a `LOGIN_SUCCESS` (resp. a `LOGIN_ERROR`) action leading to an inconsistent state.
-
+But we're not yet done. If we take a `LOGOUT` in the middle of an API call, we have to **cancel** the `authorize` process, otherwise we'll have 2 concurrent tasks evolving in parallel: The `authorize` task will continue running and upon a successful (resp. failed) result, will dispatch a `LOGIN_SUCCESS` (resp. a `LOGIN_ERROR`) action leading to an inconsistent state.
 
 In order to cancel a forked task, we use a dedicated Effect [`cancel`](http://yelouafi.github.io/redux-saga/docs/api/index.html#canceltask)
 
@@ -218,38 +174,25 @@ import { take, put, call, fork, cancel } from 'redux-saga/effects'
 // ...
 
 function* loginFlow() {
-  while(true) {
+  while (true) {
     const {user, password} = yield take('LOGIN_REQUEST')
     // fork return a Task object
     const task = yield fork(authorize, user, password)
     const action = yield take(['LOGOUT', 'LOGIN_ERROR'])
-    if(action.type === 'LOGOUT')
+    if (action.type === 'LOGOUT')
       yield cancel(task)
     yield call(Api.clearItem, 'token')
   }
 }
 ```
 
-`yield fork` results in a [Task Object](http://yelouafi.github.io/redux-saga/docs/api/index.html#task). We assign
-the returned object into a local constant `task`. Later if we take a `LOGOUT` action, we pass that task
-to the `cancel` Effect. If the task is still running, it'll be aborted. If the task has already completed
-then nothing will happen and the cancellation will result in a no-op. And finally, if the task
-completed with an error, then we do nothing, because we know the task already completed.
+`yield fork` results in a [Task Object](http://yelouafi.github.io/redux-saga/docs/api/index.html#task). We assign the returned object into a local constant `task`. Later if we take a `LOGOUT` action, we pass that task to the `cancel` Effect. If the task is still running, it'll be aborted. If the task has already completed then nothing will happen and the cancellation will result in a no-op. And finally, if the task completed with an error, then we do nothing, because we know the task already completed.
 
-Ok, we are *almost* done (yeah, concurrency it's not that easy, you have to take it seriously).
+We are *almost* done (concurrency is not that easy; you have to take it seriously).
 
-Suppose that when we receive a `LOGIN_REQUEST` action, our reducer sets some `isLoginPending` flag
-to true so it can display some message or spinner in the UI. If we get a `LOGOUT` in the middle
-of an Api call and abort the task by simply *killing it* (i.e. the task is stopped right away), then
-we may end up again with an inconsistent state. We'll still have `isLoginPending` set to true
-and our reducer will be waiting for an outcome action (`LOGIN_SUCCESS` or `LOGIN_ERROR`).
+Suppose that when we receive a `LOGIN_REQUEST` action, our reducer sets some `isLoginPending` flag to true so it can display some message or spinner in the UI. If we get a `LOGOUT` in the middle of an API call and abort the task by simply *killing it* (i.e. the task is stopped right away), then we may end up again with an inconsistent state. We'll still have `isLoginPending` set to true and our reducer will be waiting for an outcome action (`LOGIN_SUCCESS` or `LOGIN_ERROR`).
 
-Fortunately, the `cancel` Effect won't brutally kill our `authorize` task, it'll instead
-give it a chance to perform its cleanup logic. The cancelled task can handle any cancellation
-logic (as well as any other type of completion) in its `finally` block. Since a finally block
-execute on any type of completion (normal return, error, or forced cancellation), there is
-an effect `cancelled` you can use if you want handle cancellation in a special way
-
+Fortunately, the `cancel` Effect won't brutally kill our `authorize` task, it'll instead give it a chance to perform its cleanup logic. The cancelled task can handle any cancellation logic (as well as any other type of completion) in its `finally` block. Since a finally block execute on any type of completion (normal return, error, or forced cancellation), there is an Effect `cancelled` which you can use if you want handle cancellation in a special way:
 
 ```javascript
 import { take, call, put, cancelled } from 'redux-saga/effects'
@@ -263,17 +206,14 @@ function* authorize(user, password) {
   } catch(error) {
     yield put({type: 'LOGIN_ERROR', error})
   } finally {
-    if(yield cancelled()) {
+    if (yield cancelled()) {
       // ... put special cancellation handling code here
     }
-
   }
 }
 ```
 
-You may have noted that we still didn't do anyting about clearing our `isLoginPending` state.
-For that, there are 2 possible solutions (and maybe others)
+You may have noticed that we haven't done anything about clearing our `isLoginPending` state. For that, there are at least two possible solutions:
 
 - dispatch a dedicated action `RESET_LOGIN_PENDING`
-
-- or more simply, make the reducer clear the `isLoginPending` on a `LOGOUT` action.
+- more simply, make the reducer clear the `isLoginPending` on a `LOGOUT` action

--- a/docs/advanced/README.md
+++ b/docs/advanced/README.md
@@ -3,7 +3,7 @@
 In this section, we'll dig into more powerful Effects provided by the library.
 
 * [Pulling future actions](FutureActions.md)
-* [Non blocking calls](NonBlockingCalls.md)
+* [Non-blocking calls](NonBlockingCalls.md)
 * [Running tasks in parallel](RunningTasksInParallel.md)
 * [Starting a race between multiple Effects](RacingEffects.md)
 * [Sequencing Sagas using yield*](SequencingSagas.md)

--- a/docs/advanced/RacingEffects.md
+++ b/docs/advanced/RacingEffects.md
@@ -12,11 +12,11 @@ import { race, take, put } from 'redux-saga/effects'
 
 function* fetchPostsWithTimeout() {
   const {posts, timeout} = yield race({
-    posts   : call(fetchApi, '/posts'),
-    timeout : call(delay, 1000)
+    posts: call(fetchApi, '/posts'),
+    timeout: call(delay, 1000)
   })
 
-  if(posts)
+  if (posts)
     put({type: 'POSTS_RECEIVED', posts})
   else
     put({type: 'TIMEOUT_ERROR'})
@@ -26,7 +26,7 @@ function* fetchPostsWithTimeout() {
 Another useful feature of `race` is that it automatically cancels the loser Effects. For example,
 suppose we have 2 UI buttons:
 
-- The first starts a task in the background that runs in an endless loop `while(true)`
+- The first starts a task in the background that runs in an endless loop `while (true)`
 (e.g. syncing some data with the server each x seconds).
 
 - Once the background task is started, we enable a second button which will cancel the task
@@ -36,11 +36,11 @@ suppose we have 2 UI buttons:
 import { race, take, put } from 'redux-saga/effects'
 
 function* backgroundTask() {
-  while(true) { ... }
+  while (true) { ... }
 }
 
 function* watchStartBackgroundTask() {
-  while(true) {
+  while (true) {
     yield take('START_BACKGROUND_TASK')
     yield race({
       task: call(backgroundTask),

--- a/docs/advanced/RunningTasksInParallel.md
+++ b/docs/advanced/RunningTasksInParallel.md
@@ -1,10 +1,9 @@
 #Running Tasks In Parallel
 
-The `yield` statement is great for representing asynchronous control flow in a simple and linear
-style, but we also need to do things in parallel. We can't simply write:
+The `yield` statement is great for representing asynchronous control flow in a simple and linear style, but we also need to do things in parallel. We can't simply write:
 
 ```javascript
-// Wrong, effects will be executed in sequence
+// wrong, effects will be executed in sequence
 const users  = yield call(fetch, '/users'),
       repos = yield call(fetch, '/repos')
 ```
@@ -21,5 +20,4 @@ const [users, repos]  = yield [
 ]
 ```
 
-When we yield an array of effects, the generator is blocked until all the effects are resolved or as soon as
-one is rejected (just like how `Promise.all` behaves).
+When we yield an array of effects, the generator is blocked until all the effects are resolved or as soon as one is rejected (just like how `Promise.all` behaves).

--- a/docs/advanced/SequencingSagas.md
+++ b/docs/advanced/SequencingSagas.md
@@ -1,7 +1,6 @@
 # Sequencing Sagas via `yield*`
 
-You can use the builtin `yield*` operator to compose multiple Sagas in a sequential way.
-This allows you to sequence your *macro-tasks* in a simple procedural style.
+You can use the builtin `yield*` operator to compose multiple Sagas in a sequential way. This allows you to sequence your *macro-tasks* in a simple procedural style.
 
 ```javascript
 function* playLevelOne(getState) { ... }
@@ -11,7 +10,6 @@ function* playLevelTwo(getState) { ... }
 function* playLevelThree(getState) { ... }
 
 function* game(getState) {
-
   const score1 = yield* playLevelOne(getState)
   put(showScore(score1))
 
@@ -20,10 +18,7 @@ function* game(getState) {
 
   const score3 = yield* playLevelThree(getState)
   put(showScore(score3))
-
 }
 ```
 
-Note that using `yield*` will cause the JavaScript runtime to *spread* the whole sequence.
-The resulting iterator (from `game()`) will yield all values from the nested
-iterators. A more powerful alternative is to use the more generic middleware composition mechanism.
+Note that using `yield*` will cause the JavaScript runtime to *spread* the whole sequence. The resulting iterator (from `game()`) will yield all values from the nested iterators. A more powerful alternative is to use the more generic middleware composition mechanism.

--- a/docs/advanced/Testing.md
+++ b/docs/advanced/Testing.md
@@ -2,8 +2,7 @@
 
 **WIP**
 
-
-See Repository Examples
+See Repository Examples:
 
 https://github.com/yelouafi/redux-saga/blob/master/examples/counter/test/sagas.js
 

--- a/docs/advanced/UsingRunSaga.md
+++ b/docs/advanced/UsingRunSaga.md
@@ -1,11 +1,8 @@
 # Connecting Sagas to external Input/Output
 
-We saw that `take` Effects are resolved by waiting for actions to be dispatched to the Store.
-And that `put` Effects are resolved by dispatching the actions provided as argument.
+We saw that `take` Effects are resolved by waiting for actions to be dispatched to the Store. And that `put` Effects are resolved by dispatching the actions provided as argument.
 
-When a Saga is started (either at startup or later dynamically), the middleware automatically
-connects its `take`/`put` to the store. The 2 Effects can be seen as a sort of Input/Output to
-the Saga.
+When a Saga is started (either at startup or later dynamically), the middleware automatically connects its `take`/`put` to the store. The 2 Effects can be seen as a sort of Input/Output to the Saga.
 
 `redux-saga` provides a way to run a Saga outside of the redux middleware environment and connect it to a custom Input/Output.
 
@@ -26,6 +23,4 @@ runSaga(
 )
 ```
 
-
-
-For more info see [API docs](http://yelouafi.github.io/redux-saga/docs/api/index.html#runsagaiterator-subscribe-dispatch-getstate-monitor)
+For more info, see the [API docs](http://yelouafi.github.io/redux-saga/docs/api/index.html#runsagaiterator-subscribe-dispatch-getstate-monitor).

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -43,25 +43,20 @@
   * [`buffers`](#buffers)
   * [`delay(ms, [val])`](#delaymsval)
 
-
 ## Middleware API
-------------------------
 
 ### `createSagaMiddleware(options)`
 
 Creates a Redux middleware and connects the Sagas to the Redux Store
 
-- `options: Object` - A list of options to pass to the middleware. For now there is only
-one supported options: `sagaMonitor` which indicates a [SagaMonitor](#sagamonitor). If a Saga
-Monitor is provided, the middleware will deliver monitoring events to the monitor.
+- `options: Object` - A list of options to pass to the middleware. For now there is only one supported options: `sagaMonitor` which indicates a [SagaMonitor](#sagamonitor). If a SagaMonitor is provided, the middleware will deliver monitoring events to the monitor.
 
 #### Example
 
-Below we will create a function `configureStore` which will enhance the Store with a new method
-`runSaga`. Then in our main module, we will use the method to start the root Saga of the application
+Below we will create a function `configureStore` which will enhance the Store with a new method `runSaga`. Then in our main module, we will use the method to start the root Saga of the application.
 
 **configureStore.js**
-```JavaScript
+```javascript
 import createSagaMiddleware from 'redux-saga'
 import reducer from './path/to/reducer'
 
@@ -79,7 +74,7 @@ export default function configureStore(initialState) {
 ```javascript
 import configureStore from './configureStore'
 import rootSaga from './sagas'
-//... other imports
+// ... other imports
 
 const store = configureStore()
 store.runSaga(rootSaga)
@@ -87,65 +82,47 @@ store.runSaga(rootSaga)
 
 #### Notes
 
-see blow for more informations on the `sagaMiddleware.run` method
-
+See below for more information on the `sagaMiddleware.run` method.
 
 ### `middleware.run(saga, ...args)`
 
-Dynamically run `saga`. Can be used to run Sagas **only after** the `applyMiddleware` phase
+Dynamically run `saga`. Can be used to run Sagas **only after** the `applyMiddleware` phase.
 
-- `saga: Function`: A Generator function  
+- `saga: Function`: a Generator function  
 - `args: Array<any>`: arguments to be provided to `saga`
 
-The method returns a [Task descriptor](#task-descriptor)
+The method returns a [Task descriptor](#task-descriptor).
 
 #### Notes
 
-`saga` must be a function which returns a [Generator Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator).
-The middleware will then iterate over the Generator and execute all yielded Effects.
+`saga` must be a function which returns a [Generator Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator). The middleware will then iterate over the Generator and execute all yielded Effects.
 
-`saga` may also start other sagas using the various Effects provided by the library. The iteration process
-process described below is also applied to all child sagas.
+`saga` may also start other sagas using the various Effects provided by the library. The iteration process process described below is also applied to all child sagas.
 
-In the first iteration, the middleware invokes the `next()` method to retrieve the next Effect. The
-middleware then executes the yielded Effect as specified by the Effects API below. Meanwhile, the Generator
-will be suspended until the effect execution terminates. Upon receiving
-the result of the execution, the middleware calls `next(result)` on the Generator passing it the retrieved
-result as argument. This process is repeated until the Generator terminates normally or by throwing some error.
+In the first iteration, the middleware invokes the `next()` method to retrieve the next Effect. The middleware then executes the yielded Effect as specified by the Effects API below. Meanwhile, the Generator will be suspended until the effect execution terminates. Upon receiving the result of the execution, the middleware calls `next(result)` on the Generator passing it the retrieved result as an argument. This process is repeated until the Generator terminates normally or by throwing some error.
 
-If the execution results in an error (as specified by each Effect creator) then the
-`throw(error)` method of the Generator is called instead. If the Generator function defines
-a `try/catch` surrounding the current yield instruction, then the `catch` block will be invoked
-by the underlying Generator runtime. The runtime will also invoke any corresponding finally block.
+If the execution results in an error (as specified by each Effect creator) then the `throw(error)` method of the Generator is called instead. If the Generator function defines a `try/catch` surrounding the current yield instruction, then the `catch` block will be invoked by the underlying Generator runtime. The runtime will also invoke any corresponding finally block.
 
-In the case a Saga is cancelled (either manually or using the provided Effects), the middleware will
-invoke `return()` method of the Generator. This will cause the Generator to skip directly to the finally
-block.
+In the case a Saga is cancelled (either manually or using the provided Effects), the middleware will invoke `return()` method of the Generator. This will cause the Generator to skip directly to the finally block.
 
 ## Saga Helpers
---------------------------
 
->#### Notes, the following functions are helper functions built on top of the Effect creators
-below
+> Note: the following functions are helper functions built on top of the Effect creators
+below.
 
 ### `takeEvery(pattern, saga, ...args)`
 
-Spawns a `saga` on each action dispatched to the Store that matches `pattern`
-
-Each time an action is dispatched to the store. And if this action matches `pattern`, `takeEvery`
-starts a new `saga` task in the background.
+Spawns a `saga` on each action dispatched to the Store that matches `pattern`.
 
 - `pattern: String | Array | Function` - for more information see docs for [`take(pattern)`](#takepattern)
 
 - `saga: Function` - a Generator function
 
-- `args: Array<any>` - arguments to be passed to the started task. `takeEvery` will add the
-incoming action to the argument list (i.e. the action will be the last argument provided to `saga`)
+- `args: Array<any>` - arguments to be passed to the started task. `takeEvery` will add the incoming action to the argument list (i.e. the action will be the last argument provided to `saga`)
 
 #### Example
 
-In the following example, we create a simple task `fetchUser`. We use `takeEvery` to
-start a new `fetchUser` task on each dispatched `USER_REQUESTED` action
+In the following example, we create a simple task `fetchUser`. We use `takeEvery` to start a new `fetchUser` task on each dispatched `USER_REQUESTED` action:
 
 ```javascript
 import { takeEvery } from `redux-saga`
@@ -161,11 +138,11 @@ function* watchFetchUser() {
 
 #### Notes
 
-`takeEvery` is a high level API built using `take` and `fork`. Here is how the helper is implemented
+`takeEvery` is a high-level API built using `take` and `fork`. Here is how the helper is implemented:
 
 ```javascript
 function* takeEvery(pattern, saga, ...args) {
-  while(true) {
+  while (true) {
     const action = yield take(pattern)
     yield fork(saga, ...args.concat(action))
   }
@@ -179,7 +156,7 @@ click will dispatch a `USER_REQUESTED` action while the `fetchUser` fired on the
 
 `takeEvery` doesn't handle out of order responses from tasks. There is no guarantee that the tasks will
 termiate in the same order they were started. To handle out of order responses, you may consider `takeLatest`
-below
+below.
 
 ### `takeLatest(pattern, saga, ...args)`
 
@@ -219,14 +196,14 @@ function* watchLastFetchUser() {
 
 #### Notes
 
-`takeLatest` is a high level API built using `take` and `fork`. Here is how the helper is implemented
+`takeLatest` is a high-level API built using `take` and `fork`. Here is how the helper is implemented
 
 ```javascript
 function* takeLatest(pattern, saga, ...args) {
   let lastTask
-  while(true) {
+  while (true) {
     const action = yield take(pattern)
-    if(lastTask)
+    if (lastTask)
       yield cancel(lastTask) // cancel is no-op if the task has already terminateds
 
     lastTask = yield fork(saga, ...args.concat(action))
@@ -235,12 +212,12 @@ function* takeLatest(pattern, saga, ...args) {
 ```
 
 ## Effect creators
--------------------------
 
->#### Notes
-Each function below returns a plain JavaScript object and do not perform any execution
-The execution is performed by the middleware during the Iteration process described above.
-The middleware examines each Effect description and performs the appropriate action.
+> Notes:
+
+> - Each function below returns a plain JavaScript object and does not perform any execution.
+> - The execution is performed by the middleware during the Iteration process described above.
+> - The middleware examines each Effect description and performs the appropriate action.
 
 ### `take(pattern)`
 
@@ -251,27 +228,21 @@ The Generator is suspended until an action that matches `pattern` is dispatched.
 
 - If `take` is called with no arguments or `'*'` all dispatched actions are matched (e.g. `take()` will match all actions)
 
-- If it is a function, the action is matched if `pattern(action)` is true (e.g. `take(action => action.entities)`
-will match all actions having a (truthy) `entities`field.)
+- If it is a function, the action is matched if `pattern(action)` is true (e.g. `take(action => action.entities)` will match all actions having a (truthy) `entities`field.)
 
 - If it is a String, the action is matched if `action.type === pattern` (e.g. `take(INCREMENT_ASYNC)`
 
-- If it is an array, `action.type` is matched against all items in the array (e.g. `take([INCREMENT, DECREMENT])` will
-match either actions of type `INCREMENT` or `DECREMENT`).
+- If it is an array, `action.type` is matched against all items in the array (e.g. `take([INCREMENT, DECREMENT])` will match either actions of type `INCREMENT` or `DECREMENT`).
 
-The middleware provides a special action `END`. If you dispatch the END action, then all Sagas blocked on a take Effect
-will be terminated regardless of the specified pattern. If the terminated Saga has still some forked tasks which are still
-running, it will wait for all the child tasks to terminate before terminating the Task.
+The middleware provides a special action `END`. If you dispatch the END action, then all Sagas blocked on a take Effect will be terminated regardless of the specified pattern. If the terminated Saga has still some forked tasks which are still running, it will wait for all the child tasks to terminate before terminating the Task.
 
 ### `takem(pattern)`
 
-Same as `take(pattern)` but does not automatically terminate the Saga on an `END` action. Instead all Sagas blocked on a take
-Effect will get the `END` object
+Same as `take(pattern)` but does not automatically terminate the Saga on an `END` action. Instead all Sagas blocked on a take Effect will get the `END` object.
 
 ### `take(channel)`
 
-Creates an Effect description that instructs the middleware to wait for a specified message from the provided Channel. If the channel
-is already closed, then the Generator will immediately terminate following the same process described above for `take(pattern)`.
+Creates an Effect description that instructs the middleware to wait for a specified message from the provided Channel. If the channel is already closed, then the Generator will immediately terminate following the same process described above for `take(pattern)`.
 
 ### `takem(channel)`
 
@@ -281,18 +252,14 @@ Same as `take(channel)` but does not automatically terminate the Saga on an `END
 
 Creates an Effect description that instructs the middleware to dispatch an action to the Store.
 
-
-- `action: Object` - [see Redux `dispatch` documentation for complete infos](http://redux.js.org/docs/api/Store.html#dispatch)
-
+- `action: Object` - [see Redux `dispatch` documentation for complete info](http://redux.js.org/docs/api/Store.html#dispatch)
 
 ### `put(channel, action)`
 
 Creates an Effect description that instructs the middleware to put an action into the provided channel.
 
-
 - `channel: Channel` - a [`Channel`](#channel) Object.
-- `action: Object` - [see Redux `dispatch` documentation for complete infos](http://redux.js.org/docs/api/Store.html#dispatch)
-
+- `action: Object` - [see Redux `dispatch` documentation for complete info](http://redux.js.org/docs/api/Store.html#dispatch)
 
 ### `call(fn, ...args)`
 
@@ -330,7 +297,7 @@ invoke object methods.
 
 ### `apply(context, fn, args)`
 
-Alias for `call([context, fn], ...args)`
+Alias for `call([context, fn], ...args)`.
 
 ### `cps(fn, ...args)`
 
@@ -355,10 +322,9 @@ The middleware remains suspended until `fn` terminates.
 
 Supports passing a `this` context to `fn` (object method invocation)
 
-
 ### `fork(fn, ...args)`
 
-Creates an Effect description that instructs the middleware to perform a *non blocking call* on `fn`
+Creates an Effect description that instructs the middleware to perform a *non-blocking call* on `fn`
 
 #### Arguments
 
@@ -369,7 +335,7 @@ Creates an Effect description that instructs the middleware to perform a *non bl
 #### Note
 
 `fork`, like `call`, can be used to invoke both normal and Generator functions. But, the calls are
-non blocking, the middleware doesn't suspend the Generator while waiting for the result of `fn`.
+non-blocking, the middleware doesn't suspend the Generator while waiting for the result of `fn`.
 Instead as soon as `fn` is invoked, the Generator resumes immediately.
 
 `fork`, alongside `race`, is a central Effect for managing concurrency between Sagas.
@@ -427,17 +393,17 @@ A cancelled Generator can catch `SagaCancellationException`s in order to perform
 logic before it terminates (e.g. clear a `isFetching` flag in the state if the Generator was
 in middle of an AJAX call).
 
-*Note that uncaught `SagaCancellationException`s are not bubbled upward, if a Generator
+Note that uncaught `SagaCancellationException`s are not bubbled upward, if a Generator
 doesn't handle cancellation exceptions, the exception will not bubble to its parent
 Generator.
 
-`cancel` is a non blocking Effect. i.e. the Generator will resume immediately after
+`cancel` is a non-blocking Effect. i.e. the Generator will resume immediately after
 throwing the cancellation exception.
 
 For functions which return Promise results, you can plug your own cancellation logic
 by attaching a `[CANCEL]` to the promise.
 
-The following example shows how to attach cancellation logic to a Promise result :
+The following example shows how to attach cancellation logic to a Promise result:
 
 ```javascript
 import { fork, cancel, CANCEL } from 'redux-saga/effects'
@@ -472,9 +438,9 @@ current state and optionally some arguments and returns a slice of the current S
 If `select` is called without argument (i.e. `yield select()`) then the effect is resolved
 with the entire state (the same result of a `getState()` call).
 
->It's important to note that when an action is dispatched to the store. The middleware first
-forwards the action to the reducers then notifies the Sagas. It means that when you query the
-Store's State, you get the state **after** the action has been applied
+> It's important to note that when an action is dispatched to the store, the middleware first
+forwards the action to the reducers and then notifies the Sagas. This means that when you query the
+Store's State, you get the State **after** the action has been applied.
 
 #### Notes
 
@@ -485,7 +451,7 @@ find it more convenient for a Saga to query the state instead of maintaining the
 (for example, when a Saga duplicates the logic of invoking some reducer to compute a state that was
 already computed by the Store).
 
-for example, suppose we have this state shape in our application
+For example, suppose we have this state shape in our application:
 
 ```javascript
 state = {
@@ -493,15 +459,14 @@ state = {
 }
 ```
 
-We can create a *selector*, i.e. a function which knows how to extract
-the `cart` data from the State
+We can create a *selector*, i.e. a function which knows how to extract the `cart` data from the State:
 
 `./selectors`
 ```javascript
 export const getCart = state => state.cart
 ```
 
-Then we can use that selector from inside a Saga using the `select` Effect
+Then we can use that selector from inside a Saga using the `select` Effect:
 
 `./sagas.js`
 ```javascript
@@ -512,28 +477,22 @@ function* checkout() {
   // query the state using the exported selector
   const cart = yield select(getCart)
 
-  // ... call some Api endpoint then dispatch a success/error action
+  // ... call some API endpoint then dispatch a success/error action
 }
 
 export default function* rootSaga() {
-  while(true) {
+  while (true) {
     yield take('CHECKOUT_REQUEST')
     yield fork(checkout)
   }
 }
 ```
 
-`checkout` can get the needed information directly by using
-`select(getCart)`. The Saga is coupled only with the `getCart` selector. If we have
-many Sagas (or React Components) that needs to access the `cart` slice, they will all be
-coupled to the same function `getCart`. And if we now change the state shape, we need only
-to update `getCart`.
+`checkout` can get the needed information directly by using `select(getCart)`. The Saga is coupled only with the `getCart` selector. If we have many Sagas (or React Components) that needs to access the `cart` slice, they will all be coupled to the same function `getCart`. And if we now change the state shape, we need only to update `getCart`.
 
 ### `actionChannel(pattern, [buffer])`
 
-Creates an effect that instructs the middleware to queue the actions matching `pattern` using an event channel.
-Optionally you can provide a buffer
-to control buffering of the queued actions.
+Creates an effect that instructs the middleware to queue the actions matching `pattern` using an event channel. Optionally, you can provide a buffer to control buffering of the queued actions.
 
 `pattern:` - see API for `take(pattern)`
 `buffer: Buffer` - a [Buffer](#buffer) object
@@ -550,7 +509,7 @@ import api from '...'
 
 function* takeOneAtMost() {
   const chan = yield actionChannel('USER_REQUEST')
-  while(true) {
+  while (true) {
     const {payload} = yield take(chan)
     yield call(api.getUser, payload)
   }
@@ -570,7 +529,7 @@ function* saga() {
   try {
     // ...
   } finally {
-    if(yield cancelled()) {
+    if (yield cancelled()) {
       // logic that should execute only on Cancellation
     }
     // logic that should execute in all situations (e.g. closing a channel)
@@ -579,7 +538,6 @@ function* saga() {
 ```
 
 ## Effect combinators
-----------------------------
 
 ### `race(effects)`
 
@@ -590,7 +548,7 @@ multiple Effects (this is similar to how `Promise.race([...])` behaves).
 
 #### Example
 
-The following example run a race between 2 effects :
+The following example runs a race between two effects:
 
 1. A call to a function `fetchUsers` which returns a Promise
 2. A `CANCEL_FETCH` action which may be eventually dispatched on the Store
@@ -617,7 +575,6 @@ will be a single keyed object `{cancel: action}`, where action is the dispatched
 
 When resolving a `race`, the middleware automatically cancels all the losing Effects.
 
-
 ### `[...effects] (parallel effects)`
 
 Creates an Effect description that instructs the middleware to run multiple Effects
@@ -625,7 +582,7 @@ in parallel and wait for all of them to complete.
 
 #### Example
 
-The following example run 2 blocking calls in parallel :
+The following example runs two blocking calls in parallel:
 
 ```javascript
 import { fetchCustomers, fetchProducts } from './path/to/api'
@@ -640,22 +597,17 @@ function* mySaga() {
 
 #### Notes
 
-When running Effects in parallel, the middleware suspends the Generator until one
-of the followings :  
+When running Effects in parallel, the middleware suspends the Generator until one of the following occurs:
 
-- All the Effects completed with success: resumes the Generator with an array containing
-the results of all Effects.
+- All the Effects completed with success: resumes the Generator with an array containing the results of all Effects.
 
-- One of the Effects was rejected before all the effects complete: throw the rejection
-error inside the Generator.
+- One of the Effects was rejected before all the effects complete: throws the rejection error inside the Generator.
 
 ## Interfaces
----------------------
 
 ### Task
 
-The Task interface specifies the result of running a Saga using `fork`, `middleware.run` or `runSaga`
-
+The Task interface specifies the result of running a Saga using `fork`, `middleware.run` or `runSaga`.
 
 <table id="task-descriptor">
   <tr>
@@ -696,8 +648,7 @@ The Task interface specifies the result of running a Saga using `fork`, `middlew
 
 ### Channel
 
-A channel is an object used to send and receive messages between tasks. Messages from senders are queued until
-an interested receiver request a message, and registered receiver is queued until a message is disponible.
+A channel is an object used to send and receive messages between tasks. Messages from senders are queued until an interested receiver request a message, and registered receiver is queued until a message is disponible.
 
 Every channel has an underlying buffer which defines the buffering strategy (fixed size, dropping, sliding)
 
@@ -715,9 +666,7 @@ The Channel interface defines 3 methods: `take`, `put` and `close`
 - If there are pending takers, then invoke the oldest taker with the message.  
 - Otherwise put the message on the underlying buffer
 
-`Channel.close():` closes the channel which means no more puts will be allowed. If there are pending takers and no
-buffered messages, then all takers will be invoked with `END`. If there are buffered messages, then thoses messages will
-be delivered first to takers until the buffer become empty. Any remaining takers will be then invoked with `END`.
+`Channel.close():` closes the channel which means no more puts will be allowed. If there are pending takers and no buffered messages, then all takers will be invoked with `END`. If there are buffered messages, then those messages will be delivered first to takers until the buffer become empty. Any remaining takers will be then invoked with `END`.
 
 
 ### Buffer
@@ -751,9 +700,9 @@ connect a Saga to external input/output, other than store actions.
       - `input: any` - argument passed by `subscribe` to `callback` (see Notes below)
 
     - `dispatch(output): Function` - used to fulfill `put` effects.
-      - `output : any` -  argument provided by the Saga to the `put` Effect (see Notes below).
+      - `output: any` -  argument provided by the Saga to the `put` Effect (see Notes below).
 
-    - `getState() : Function` - used to fulfill `select` and `getState` effects
+    - `getState(): Function` - used to fulfill `select` and `getState` effects
 
 - `monitor(sagaAction): Function` (optional): a callback which is used to dispatch all Saga related events. In the middleware version, all actions are dispatched to the Redux store. See the [sagaMonitor example](https://github.com/yelouafi/redux-saga/tree/master/examples/sagaMonitor) for usage.
   - `sagaAction: Object` - action dispatched by Sagas to notify `monitor` of Saga related events.
@@ -772,23 +721,19 @@ if the take pattern matches the currently incoming input, the Saga is resumed wi
 is invoked with output.
 
 ## Utils
-------------
 
 ### `channel([buffer])`
 
 A factory method that can be used to create Channels. You can optionnally pass it a buffer
 to control how the channel buffers the messages.
 
-By default, if no buffer is provided, the channel will queue all incoming messages until interested takers are registered.
-The default buffering will deliver message using a FIFO strategy: a new taker will be delivered the oldest message in the buffer.
+By default, if no buffer is provided, the channel will queue all incoming messages until interested takers are registered. The default buffering will deliver message using a FIFO strategy: a new taker will be delivered the oldest message in the buffer.
 
 ### `eventChannel(subscribe, [buffer], [matcher])`
 
-Creates channel that will subscribe to an event source using the `subscribe` method. Incoming events from the
-event source will be queued in the channel until interested takers are registered.
+Creates channel that will subscribe to an event source using the `subscribe` method. Incoming events from the event source will be queued in the channel until interested takers are registered.
 
-- `subscribe: Function` used to subscribe to the underlying event source. The function must return an unsubscribe function
-to terminate the subscription.
+- `subscribe: Function` used to subscribe to the underlying event source. The function must return an unsubscribe function to terminate the subscription.
 
 - `buffer: Buffer` optional Buffer object to buffer messages on this channel. If not provided messages will not buffered
 on this channel.
@@ -808,9 +753,9 @@ const countdown = (secs) => {
       const iv = setInterval(() => {
         console.log('countdown', secs)
         secs -= 1
-        if(secs > 0)
+        if (secs > 0) {
           listener(secs)
-        else {
+        } else {
           listener(END)
           clearInterval(iv)
           console.log('countdown terminated')
@@ -839,4 +784,4 @@ Provides some common buffers
 
 ### `delay(ms, [val])`
 
-  returns a Promise that will resolve after `ms` milliseconds with `val`
+Returns a Promise that will resolve after `ms` milliseconds with `val`.

--- a/docs/basics/DeclarativeEffects.md
+++ b/docs/basics/DeclarativeEffects.md
@@ -1,21 +1,14 @@
 # Declarative Effects
 
-In `redux-saga`, Sagas are implemented using Generator functions. To express the Saga logic
-we yield plain JavaScript Objects from the Generator. We call those Objects *Effects*. An
-Effect is simply an object which contains some information to be interpreted by the middleware.
-You can view Effects like instructions to the middleware to perform some operation (invoke
-some asynchronous function, dispatch an action to the store).
+In `redux-saga`, Sagas are implemented using Generator functions. To express the Saga logic we yield plain JavaScript Objects from the Generator. We call those Objects *Effects*. An Effect is simply an object which contains some information to be interpreted by the middleware. You can view Effects like instructions to the middleware to perform some operation (invoke some asynchronous function, dispatch an action to the store).
 
 To create Effects, you use the functions provided by the library in the `redux-saga/effects` package.
 
-In this section and the following, we will introduce some basic Effects. And see how the concept
-allows the Sagas to be easily tested.
-
+In this section and the following, we will introduce some basic Effects. And see how the concept allows the Sagas to be easily tested.
 
 Sagas can yield Effects in multiple forms. The simplest way is to yield a Promise.
 
-For example suppose we have a Saga that watches a `PRODUCTS_REQUESTED` action. On each matching
-action, it starts a task to fetch a list of products from a server.
+For example suppose we have a Saga that watches a `PRODUCTS_REQUESTED` action. On each matching action, it starts a task to fetch a list of products from a server.
 
 ```javascript
 import { takeEvery } from 'redux-saga'
@@ -31,45 +24,33 @@ function* fetchProducts() {
 }
 ```
 
-In the example above, we are invoking `Api.fetch` directly from inside the Generator (In
-Generator functions, any expression at the right of `yield` is evaluated then the result is
-yielded to the caller).
+In the example above, we are invoking `Api.fetch` directly from inside the Generator (In Generator functions, any expression at the right of `yield` is evaluated then the result is yielded to the caller).
 
-`Api.fetch('/products')` triggers an AJAX request and returns a Promise that will resolve
-with the resolved response, the AJAX request will be executed immediately. Simple and idiomatic but...
+`Api.fetch('/products')` triggers an AJAX request and returns a Promise that will resolve with the resolved response, the AJAX request will be executed immediately. Simple and idiomatic, but...
 
 Suppose we want to test generator above:
 
 ```javascript
 const iterator = fetchProducts()
-assert.deepEqual( iterator.next().value, ?? ) // what do we expect ?
+assert.deepEqual(iterator.next().value, ??) // what do we expect ?
 ```
 
-We want to check the result of the first value yielded by the generator. In our case it's the result of running
-`Api.fetch('/products')` which is a Promise . Executing the real service during tests is neither a viable nor
-practical approach, so we have to *mock* the `Api.fetch` function, i.e. we'll have to replace the real
-function with a fake one which doesn't actually run the AJAX request but only checks that we've called `Api.fetch`
-with the right arguments (`'/products'` in our case).
+We want to check the result of the first value yielded by the generator. In our case it's the result of running `Api.fetch('/products')` which is a Promise . Executing the real service during tests is neither a viable nor practical approach, so we have to *mock* the `Api.fetch` function, i.e. we'll have to replace the real function with a fake one which doesn't actually run the AJAX request but only checks that we've called `Api.fetch` with the right arguments (`'/products'` in our case).
 
-Mocks make testing more difficult and less reliable. On the other hand, functions that simply return values are
-easier to test, since we can use a simple `equal()` to check the result. This is the way to write the most reliable tests.
+Mocks make testing more difficult and less reliable. On the other hand, functions that simply return values are easier to test, since we can use a simple `equal()` to check the result. This is the way to write the most reliable tests.
 
 Not convinced? I encourage you to read [Eric Elliott's article](https://medium.com/javascript-scene/what-every-unit-test-needs-f6cd34d9836d#.4ttnnzpgc):
 
->(...)`equal()`, by nature answers the two most important questions every unit test must answer,
+> (...)`equal()`, by nature answers the two most important questions every unit test must answer,
 but most don’t:
 - What is the actual output?
 - What is the expected output?
 >
->If you finish a test without answering those two questions, you don’t have a real unit test.
-You have a sloppy, half-baked test.
+> If you finish a test without answering those two questions, you don’t have a real unit test. You have a sloppy, half-baked test.
 
-What we actually need is just to make sure the `fetchProducts` task yields a call with the right function
-and the right arguments.
+What we actually need is just to make sure the `fetchProducts` task yields a call with the right function and the right arguments.
 
-Instead of invoking the asynchronous function directly from inside the Generator,
-**we can yield only a description of the function invocation**. i.e. We'll simply yield
- an object which looks like
+Instead of invoking the asynchronous function directly from inside the Generator, **we can yield only a description of the function invocation**. i.e. We'll simply yield an object which looks like
 
 ```javascript
 // Effect -> call the function Api.fetch with `./products` as argument
@@ -81,10 +62,7 @@ Instead of invoking the asynchronous function directly from inside the Generator
 }
 ```
 
-Put another way, the Generator will yield plain Objects containing *instructions*, and the `redux-saga`
-middleware will take care of executing those instructions and giving back the result of their
-execution to the Generator. This way, when testing the Generator, all we need to do is to check
-that it yields the expected instruction by doing a simple `deepEqual` on the yielded Object.
+Put another way, the Generator will yield plain Objects containing *instructions*, and the `redux-saga` middleware will take care of executing those instructions and giving back the result of their execution to the Generator. This way, when testing the Generator, all we need to do is to check that it yields the expected instruction by doing a simple `deepEqual` on the yielded Object.
 
 For this reason, the library provides a different way to perform asynchronous calls.
 
@@ -97,14 +75,9 @@ function* fetchProducts() {
 }
 ```
 
-We're using now the `call(fn, ...args)` function. **The difference from the preceding example is that now we're not
-executing the fetch call immediately, instead, `call` creates a description of the effect**. Just as in
-Redux you use action creators to create a plain object describing the action that will get executed by the Store,
-`call` creates a plain object describing the function call. The redux-saga middleware takes care of executing
-the function call and resuming the generator with the resolved response.
+We're using now the `call(fn, ...args)` function. **The difference from the preceding example is that now we're not executing the fetch call immediately, instead, `call` creates a description of the effect**. Just as in Redux you use action creators to create a plain object describing the action that will get executed by the Store, `call` creates a plain object describing the function call. The redux-saga middleware takes care of executing the function call and resuming the generator with the resolved response.
 
-This allows us to easily test the Generator outside the Redux environment. Because `call` is just a
-function which returns a plain Object.
+This allows us to easily test the Generator outside the Redux environment. Because `call` is just a function which returns a plain Object.
 
 ```javascript
 import { call } from 'redux-saga/effects'
@@ -122,13 +95,9 @@ assert.deepEqual(
 
 Now we don't need to mock anything, and a simple equality test will suffice.
 
-The advantage of those *declarative calls* is that we can test all the logic inside a Saga
-by simply iterating over the Generator and doing a `deepEqual` test on the values
-yielded successively. This is a real benefit, as your complex asynchronous operations are no longer
-black boxes, and you can test in detail their operational logic no matter how complex it is.
+The advantage of those *declarative calls* is that we can test all the logic inside a Saga by simply iterating over the Generator and doing a `deepEqual` test on the values yielded successively. This is a real benefit, as your complex asynchronous operations are no longer black boxes, and you can test in detail their operational logic no matter how complex it is.
 
-`call` supports also invoking object methods, you can provide a `this` context to the invoked
-functions using the following form:
+`call` supports also invoking object methods, you can provide a `this` context to the invoked functions using the following form:
 
 ```javascript
 yield call([obj, obj.method], arg1, arg2, ...) // as if we did obj.method(arg1, arg2 ...)
@@ -140,9 +109,7 @@ yield call([obj, obj.method], arg1, arg2, ...) // as if we did obj.method(arg1, 
 yield apply(obj, obj.method, [arg1, arg2, ...])
 ```
 
-`call` and `apply` are well suited for functions that return Promise results. Another function
-`cps` can be used to handle Node style functions (e.g. `fn(...args, callback)` where `callback`
-is of the form `(error, result) => ()`, `cps` stands for Continuation Passing Style).
+`call` and `apply` are well suited for functions that return Promise results. Another function `cps` can be used to handle Node style functions (e.g. `fn(...args, callback)` where `callback` is of the form `(error, result) => ()`). `cps` stands for Continuation Passing Style.
 
 For example:
 
@@ -152,7 +119,7 @@ import { cps } from 'redux-saga/effects'
 const content = yield cps(readFile, '/path/to/file')
 ```
 
-And of course you can test it just like you test call:
+And of course you can test it just like you test `call`:
 
 ```javascript
 import { cps } from 'redux-saga/effects'

--- a/docs/basics/DispatchingActions.md
+++ b/docs/basics/DispatchingActions.md
@@ -7,7 +7,7 @@ We could pass the Store's `dispatch` function to the Generator. Then the
 Generator could invoke it after receiving the fetch response:
 
 ```javascript
-//...
+// ...
 
 function* fetchProducts(dispatch) {
   const products = yield call(Api.fetch, '/products')
@@ -29,7 +29,7 @@ Effect.
 
 ```javascript
 import { call, put } from 'redux-saga/effects'
-//...
+// ...
 
 function* fetchProducts() {
   const products = yield call(Api.fetch, '/products')

--- a/docs/basics/Effect.md
+++ b/docs/basics/Effect.md
@@ -1,16 +1,9 @@
 # A common abstraction: Effect
 
-To generalize, triggering Side Effects from inside a Saga is always done by yielding some
-declarative Effect (You can also yield Promise directly, but this will make testing difficult
-  as we saw in the first section)
+To generalize, triggering Side Effects from inside a Saga is always done by yielding some declarative Effect. (You can also yield Promise directly, but this will make testing difficult as we saw in the first section.)
 
-What a Saga does is actually compose all those Effects together to implement the desired control flow.
-The simplest example is to sequence yielded Effects by just putting the yields one after another. You can also use the
-familiar control flow operators (`if`, `while`, `for`) to implement more sophisticated control flows.
+What a Saga does is actually compose all those Effects together to implement the desired control flow. The simplest example is to sequence yielded Effects by just putting the yields one after another. You can also use the familiar control flow operators (`if`, `while`, `for`) to implement more sophisticated control flows.
 
-We saw that using Effects like `call` and `put`, combined with high level APIs like `takeEvery`
-allows us to achieve the same things as `redux-thunk`, but with the added benefit of easy testability.
+We saw that using Effects like `call` and `put`, combined with high-level APIs like `takeEvery` allows us to achieve the same things as `redux-thunk`, but with the added benefit of easy testability.
 
- But `redux-saga` provides another advantage over `redux-thunk`. In the Advanced section
- you'll encounter some more powerful Effects that let you express complex control flows
- while still allowing the same testability benefit.
+But `redux-saga` provides another advantage over `redux-thunk`. In the Advanced section you'll encounter some more powerful Effects that let you express complex control flows while still allowing the same testability benefit.

--- a/docs/basics/ErrorHandling.md
+++ b/docs/basics/ErrorHandling.md
@@ -1,11 +1,8 @@
 # Error handling
 
-In this section we'll see how to handle the failure case from the previous example. Let's suppose
-that our API function `Api.fetch` returns a Promise which gets rejected when the remote fetch fails
-for some reason.
+In this section we'll see how to handle the failure case from the previous example. Let's suppose that our API function `Api.fetch` returns a Promise which gets rejected when the remote fetch fails for some reason.
 
-We want to handle those errors inside our Saga by dispatching a `PRODUCTS_REQUEST_FAILED` action
-to the Store.
+We want to handle those errors inside our Saga by dispatching a `PRODUCTS_REQUEST_FAILED` action to the Store.
 
 We can catch errors inside the Saga using the familiar `try/catch` syntax.
 
@@ -13,7 +10,7 @@ We can catch errors inside the Saga using the familiar `try/catch` syntax.
 import Api from './path/to/api'
 import { call, put } from 'redux-saga/effects'
 
-//...
+// ...
 
 function* fetchProducts() {
   try {
@@ -52,12 +49,9 @@ assert.deepEqual(
 )
 ```
 
-In this case, we're passing the `throw` method a fake error. This will cause the Generator
-to break the current flow and execute the catch block.
+In this case, we're passing the `throw` method a fake error. This will cause the Generator to break the current flow and execute the catch block.
 
-Of course you're not forced to handle your API errors inside `try`/`catch` blocks, you can also make
-your API service return a normal value with some error flag on it. For example, you can catch Promise
-rejections and map them to an object with an error field.
+Of course, you're not forced to handle your API errors inside `try`/`catch` blocks. You can also make your API service return a normal value with some error flag on it. For example, you can catch Promise rejections and map them to an object with an error field.
 
 ```javascript
 import Api from './path/to/api'
@@ -71,7 +65,7 @@ function fetchProductsApi() {
 
 function* fetchProducts() {
   const { response, error } = yield call(fetchProductsApi)
-  if(response)
+  if (response)
     yield put({ type: 'PRODUCTS_RECEIVED', products: response })
   else
     yield put({ type: 'PRODUCTS_REQUEST_FAILED', error })

--- a/docs/basics/README.md
+++ b/docs/basics/README.md
@@ -2,6 +2,6 @@
 
 * [Using Saga Helpers](UsingSagaHelpers.md)
 * [Declarative Effects](DeclarativeEffects.md)
-* [Dispatching actions](DispatchingActions.md)
-* [Error handling](ErrorHandling.md)
-* [A common abstraction: Effect](Effect.md)
+* [Dispatching Actions](DispatchingActions.md)
+* [Error Handling](ErrorHandling.md)
+* [A Common Abstraction: Effect](Effect.md)

--- a/docs/basics/UsingSagaHelpers.md
+++ b/docs/basics/UsingSagaHelpers.md
@@ -1,19 +1,14 @@
 # Using Saga Helpers
 
-redux-saga provides some helper functions to spawn tasks when some specific actions are
-dispatched to the Store.
+redux-saga provides some helper functions to spawn tasks when some specific actions are dispatched to the Store.
 
-The helper functions are built on top of the lower level API. In the advanced section,
-we'll see how those functions can be implemented.
+The helper functions are built on top of the lower level API. In the advanced section, we'll see how those functions can be implemented.
 
-The first function, `takeEvery` is the most familiar and provides a behavior similar to
-redux-thunk.
+The first function, `takeEvery` is the most familiar and provides a behavior similar to redux-thunk.
 
-Let's illustrate with the common AJAX example. On each click on a Fetch button
-we dispatch a `FETCH_REQUESTED` action. We want to handle this action by launching
-a task that will fetch some data from the server.
+Let's illustrate with the common AJAX example. On each click on a Fetch button we dispatch a `FETCH_REQUESTED` action. We want to handle this action by launching a task that will fetch some data from the server.
 
-First we create the task that will perform the asynchronous action
+First we create the task that will perform the asynchronous action:
 
 ```javascript
 import { call, put } from 'redux-saga/effects'
@@ -28,7 +23,7 @@ export function* fetchData(action) {
 }
 ```
 
-To launch the above task on each `FETCH_REQUESTED` action
+To launch the above task on each `FETCH_REQUESTED` action:
 
 ```javascript
 import { takeEvery } from 'redux-saga'
@@ -38,14 +33,9 @@ function* watchFetchData() {
 }
 ```
 
-In the above example, `takeEvery` allows multiple `fetchData` instances to be started
-concurrently. At a given moment, we can start a new `fetchData` task while there are
-still one or more previous `fetchData` which have not yet terminated.
+In the above example, `takeEvery` allows multiple `fetchData` instances to be started concurrently. At a given moment, we can start a new `fetchData` task while there are still one or more previous `fetchData` which have not yet terminated.
 
-If we want to only get the response of the latest request fired
-(e.g. to display always the latest version of data) we can use the `takeLatest`
-helper.
-
+If we want to only get the response of the latest request fired (e.g. to display always the latest version of data) we can use the `takeLatest` helper:
 
 ```javascript
 import { takeLatest } from 'redux-saga'
@@ -55,6 +45,4 @@ function* watchFetchData() {
 }
 ```
 
-Unlike `takeEvery`, `takeLatest` allows only one `fetchData` task to run at any moment. And it's
-the latest started task. If a previous task is still running, it'll be automatically
-cancelled.
+Unlike `takeEvery`, `takeLatest` allows only one `fetchData` task to run at any moment. And it's the latest started task. If a previous task is still running, it'll be automatically cancelled.

--- a/docs/introduction/BeginnerTutorial.md
+++ b/docs/introduction/BeginnerTutorial.md
@@ -4,49 +4,38 @@
 
 This tutorial attempts to introduce redux-saga in a (hopefully) accessible way.
 
-For our getting started tutorial, we are going to use the trivial Counter demo from the Redux repo.
-The application is quite simple but is a good fit to illustrate the basic concepts of redux-saga
-without being lost in excessive details.
+For our getting started tutorial, we are going to use the trivial Counter demo from the Redux repo. The application is quite simple but is a good fit to illustrate the basic concepts of redux-saga without being lost in excessive details.
 
 ### The initials setup
 
-Before we start, you have to clone the repository at
+Before we start, clone the [tutorial repository](https://github.com/yelouafi/redux-saga-beginner-tutorial).
 
-https://github.com/yelouafi/redux-saga-beginner-tutorial
+> The final code of this tutorial is located in the `sagas` branch.
 
->The final code of this tutorial is located in the sagas branch
+Then in the command line, run:
 
-Then in the command line, type
-
-```
-cd redux-saga-beginner-tutorial
-npm install
+```sh
+$ cd redux-saga-beginner-tutorial
+$ npm install
 ```
 
-To run the application type
+To start the application, run:
 
+```sh
+$ npm start
 ```
-npm start
-```
 
-We are starting with the simplest use case: 2 buttons to `Increment` and `Decrement` a counter.
-Later, we will introduce asynchronous calls.
+We are starting with the simplest use case: 2 buttons to `Increment` and `Decrement` a counter. Later, we will introduce asynchronous calls.
 
-If things go well, you should see 2 buttons `Increment` and `Decrement` along with a message
-below showing `Counter : 0`.
+If things go well, you should see 2 buttons `Increment` and `Decrement` along with a message below showing `Counter: 0`.
 
->In case you encountered an issue with running the application. Feel free to create an issue
-on the Tutorial repo
-
->https://github.com/yelouafi/redux-saga-beginner-tutorial/issues
-
+> In case you encountered an issue with running the application. Feel free to create an issue on the [tutorial repo](https://github.com/yelouafi/redux-saga-beginner-tutorial/issues).
 
 ## Hello Sagas!
 
-We are going to create our first Saga. Following the tradition, we will write our 'Hello, world'
-version for Sagas.
+We are going to create our first Saga. Following the tradition, we will write our 'Hello, world' version for Sagas.
 
-Create a file `sagas.js` then add the following snippet
+Create a file `sagas.js` then add the following snippet:
 
 ```javascript
 export function* helloSaga() {
@@ -54,23 +43,21 @@ export function* helloSaga() {
 }
 ```
 
-So nothing scary, just a normal function (Ok except for the `*`). All it does
-is print a greeting message into the console.
+So nothing scary, just a normal function (except for the `*`). All it does is print a greeting message into the console.
 
-In order to run our Saga, we need to
+In order to run our Saga, we need to:
 
 - create a Saga middleware with a list of Sagas to run (so far we have only one `helloSaga`)
 - connect the Saga middleware to the Redux store
 
-
-We will make the changes to `main.js`
+We will make the changes to `main.js`:
 
 ```javascript
 // ...
 import { createStore, applyMiddleware } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 
-//...
+// ...
 import { helloSaga } from './sagas'
 
 const sagaMiddleware = createSagaMiddleware()
@@ -83,27 +70,21 @@ sagaMiddleware.run(helloSaga)
 // rest unchanged
 ```
 
-First we import our Saga from the `./sagas` module. Then we create a middleware using the factory function
-`createSagaMiddleware` exported by the `redux-saga` library.
+First we import our Saga from the `./sagas` module. Then we create a middleware using the factory function `createSagaMiddleware` exported by the `redux-saga` library.
 
-Before running our `helloSaga`, we must connect our middleware to the Store using `applyMiddleware`. Then we
-can use the `sagaMiddleware.run(helloSaga)` to start our Saga.
-
+Before running our `helloSaga`, we must connect our middleware to the Store using `applyMiddleware`. Then we can use the `sagaMiddleware.run(helloSaga)` to start our Saga.
 
 So far, our Saga does nothing special. It just logs a message then exits.
 
-
 ## Making Asynchronous calls
 
-Now let's add something closer to the original Counter demo. To illustrate asynchronous calls, we will add another button
-to increment the counter 1 second after the click.
+Now let's add something closer to the original Counter demo. To illustrate asynchronous calls, we will add another button to increment the counter 1 second after the click.
 
-First things first, we'll provide an additional callback `onIncrementAsync` to the UI component.
+First thing's first, we'll provide an additional callback `onIncrementAsync` to the UI component.
 
 ```javascript
 const Counter = ({ value, onIncrement, onDecrement, onIncrementAsync }) =>
   <div>
-    ...
     {' '}
     <button onClick={onIncrementAsync}>Increment after 1 second</button>
     <hr />
@@ -119,7 +100,6 @@ We will modify the `main.js` module as follows
 function render() {
   ReactDOM.render(
     <Counter
-      ...
       onIncrementAsync={() => action('INCREMENT_ASYNC')}
     />,
     document.getElementById('root')
@@ -129,14 +109,13 @@ function render() {
 
 Note that unlike in redux-thunk, our component dispatches a plain object action.
 
-Now we will introduce another Saga to perform the asynchronous call. Our use case is as follows
+Now we will introduce another Saga to perform the asynchronous call. Our use case is as follows:
 
 > On each `INCREMENT_ASYNC` action, we want to start a task that will do the following
 
->- Wait 1 second then increment the counter
+> - Wait 1 second then increment the counter
 
-
-Add the following code to the `sagas.js` module
+Add the following code to the `sagas.js` module:
 
 ```javascript
 import { takeEvery, delay } from 'redux-saga'
@@ -154,34 +133,19 @@ export function* watchIncrementAsync() {
 }
 ```
 
-Ok time for some explanations. First we create an utility function `delay` which returns a Promise
-that will resolve after a specified number of milliseconds. We'll use this function to *block* the Generator.
+Time for some explanations. First we create an utility function `delay` which returns a Promise that will resolve after a specified number of milliseconds. We'll use this function to *block* the Generator.
 
-Sagas, which are implemented as Generator functions, yield objects to the
-redux-saga middleware. The yielded objects are a kind of instructions to be interpreted by
-the middleware. When the middleware retrieves a yielded Promise, it'll suspend the Saga until
-the Promise completes. In the above example, the `incrementAsync` Saga will be suspended until
-the Promise returned by `delay` resolves, which will happen after 1 second.
+Sagas, which are implemented as Generator functions, yield objects to the redux-saga middleware. The yielded objects are a kind of instructions to be interpreted by the middleware. When the middleware retrieves a yielded Promise, it'll suspend the Saga until the Promise completes. In the above example, the `incrementAsync` Saga will be suspended until the Promise returned by `delay` resolves, which will happen after 1 second.
 
-Once the Promise is resolved, the middleware will resume the Saga to execute the next statement
-(more accurately to execute all the following statements until the next yield). In our case, the
-next statement is another yielded object: which is the result of calling `put({type: 'INCREMENT'})`.
-It means the Saga instructs the middleware to dispatch an `INCREMENT` action.
+Once the Promise is resolved, the middleware will resume the Saga to execute the next statement (more accurately to execute all the following statements until the next yield). In our case, the next statement is another yielded object: which is the result of calling `put({type: 'INCREMENT'})`. It means the Saga instructs the middleware to dispatch an `INCREMENT` action.
 
-`put` is one example of what we call an *Effect*. Effects are simple JavaScript Objects which
-contain instructions to be fulfilled by the middleware. When a middleware retreives an Effect
-yielded by a Saga, it pauses the Saga until the Effect is fullfilled, then the Saga is resumed
-again.
+`put` is one example of what we call an *Effect*. Effects are simple JavaScript Objects which contain instructions to be fulfilled by the middleware. When a middleware retrieves an Effect yielded by a Saga, it pauses the Saga until the Effect is fulfilled, then the Saga is resumed again.
 
-So to summarize, the `incrementAsync` Saga sleeps for 1 second via the call to `delay(1000)`, then
-dispatches an `INCREMENT` action.
+So to summarize, the `incrementAsync` Saga sleeps for 1 second via the call to `delay(1000)`, then dispatches an `INCREMENT` action.
 
-Next, we created another Saga `watchIncrementAsync`. The Saga will watch the dispatched `INCREMENT_ASYNC`
-actions and spawn a new `incrementAsync` task on each action. For this purpose, we use a helper function
-provided by the library `takeEvery` which will perform the process above.
+Next, we created another Saga `watchIncrementAsync`. The Saga will watch the dispatched `INCREMENT_ASYNC` actions and spawn a new `incrementAsync` task on each action. For this purpose, we use a helper function provided by the library `takeEvery` which will perform the process above.
 
-So now we have 2 Sagas and we need to start them both at once. We'll add a `rootSaga` which will start
-the 2 in parallel. In the same file sagas.js, add the following code
+So now we have 2 Sagas and we need to start them both at once. We'll add a `rootSaga` which will start the two in parallel. In the same file `sagas.js`, add the following code:
 
 ```javascript
 // single entry point to start all Sagas at once
@@ -193,27 +157,24 @@ export default function* rootSaga() {
 }
 ```
 
-We're yielding an array with the results of the calls to the 2 sagas. This means the 2 resulting Generators
-will be started in parallel. We also made `rootSaga` the default export for our sagas module. So we'll have to
-invoke `sagaMiddleware.run` only on the root Saga.
-
+We're yielding an array with the results of the calls to the 2 sagas. This means the 2 resulting Generators will be started in parallel. We also made `rootSaga` the default export for our sagas module. So we'll have to invoke `sagaMiddleware.run` only on the root Saga.
 
 ```javascript
-//...
+// ...
 import rootSaga from './sagas'
 
 const sagaMiddleware = createSagaMiddleware()
 const store = ...
 sagaMiddleware.run(rootSaga)
 
-//...
+// ...
 ```
 
 ## Making our code testable
 
 We want to test our `incrementAsync` Saga to make sure it performs the desired task.
 
-Create another file `saga.spec.js`
+Create another file `saga.spec.js`:
 
 ```javascript
 import test from 'tape';
@@ -242,7 +203,6 @@ In the case of `incrementAsync`, the generator yields 2 values consecutively:
 
 1. `yield delay(1000)`
 2. `yield put({type: 'INCREMENT'})`
-
 
 So if we invoke the next method of the generator 3 times consecutively we get the following
 results:
@@ -280,12 +240,11 @@ test('incrementAsync Saga test', (assert) => {
 The issue is how do we test the return value of `delay`? We can't do a simple equality test
 on Promises. If `delay` returned a *normal* value, things would've been be easier to test.
 
-Well, `redux-saga` provides a way which makes the above statement possible. Instead of calling
-`delay(1000)` directly inside `incrementAsync`, we'll call it *indirectly*
-
+Well, `redux-saga` provides a way to make the above statement possible. Instead of calling
+`delay(1000)` directly inside `incrementAsync`, we'll call it *indirectly*:
 
 ```javascript
-//...
+// ...
 import { put, call } from 'redux-saga/effects'
 import { delay } from 'redux-saga'
 
@@ -296,29 +255,20 @@ export function* incrementAsync() {
 }
 ```
 
-Instead of doing `yield delay(1000)`, we're now doing `yield call(delay, 1000)` so what's the difference ?
+Instead of doing `yield delay(1000)`, we're now doing `yield call(delay, 1000)`. What's the difference?
 
-In the first case, the yield expression `delay(1000)` is evaluated before it gets passed to the caller of `next`
-(the caller could be the middleware when running our code. It could also be our test code which runs the Generator
-function and iterates over the returned Generator). So what the caller gets is a Promise, like in the test code
-above.
+In the first case, the yield expression `delay(1000)` is evaluated before it gets passed to the caller of `next` (the caller could be the middleware when running our code. It could also be our test code which runs the Generator function and iterates over the returned Generator). So what the caller gets is a Promise, like in the test code above.
 
-In the second case, the yield expression `call(delay, 1000)` is what gets passed to the caller of `next`. `call`
-just like `put`, returns an Effect which instructs the middleware to call a given function with the given arguments.
-In fact, neither `put` nor `call` performs any dispatch or asynchronous call by themselves, they simply return
-plain JavaScript objects.
+In the second case, the yield expression `call(delay, 1000)` is what gets passed to the caller of `next`. `call` just like `put`, returns an Effect which instructs the middleware to call a given function with the given arguments. In fact, neither `put` nor `call` performs any dispatch or asynchronous call by themselves, they simply return plain JavaScript objects.
 
 ```javascript
 put({type: 'INCREMENT'}) // => { PUT: {type: 'INCREMENT'} }
 call(delay, 1000)        // => { CALL: {fn: delay, args: [1000]}}
 ```
 
-What happens is that the middleware examines the type of each yielded Effect then decides how
-to fulfill that Effect. If the Effect type is a `PUT` then it'll dispatch an action to the Store.
-If the Effect is a `CALL` then it'll call the given function.
+What happens is that the middleware examines the type of each yielded Effect then decides how to fulfill that Effect. If the Effect type is a `PUT` then it will dispatch an action to the Store. If the Effect is a `CALL` then it'll call the given function.
 
-This separation between Effect creation and Effect execution makes possible to test our Generator
-in a surprisingly easy way
+This separation between Effect creation and Effect execution makes it possible to test our Generator in a surprisingly easy way:
 
 ```javascript
 import test from 'tape';
@@ -351,13 +301,12 @@ test('incrementAsync Saga test', (assert) => {
 });
 ```
 
-Since `put` and `call` return plain objects, we can reuse the same functions in our test
-code. And to test the logic of `incrementAsync`, we simply iterate over the generator
-and do `deepEqual` tests on its values.
+Since `put` and `call` return plain objects, we can reuse the same functions in our test code. And to test the logic of `incrementAsync`, we simply iterate over the generator and do `deepEqual` tests on its values.
 
-In order to run the above test, type
-```
-npm test
+In order to run the above test, run:
+
+```sh
+$ npm test
 ```
 
-which should report the results on the console
+which should report the results on the console.

--- a/docs/introduction/SagaBackground.md
+++ b/docs/introduction/SagaBackground.md
@@ -1,4 +1,4 @@
-# Saga background
+# Background on the Saga concept
 
 **WIP**
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,21 +1,18 @@
-## Recipes
+# Recipes
 
-### Throttling
+## Throttling
 
-You can throttle a sequence of dispatched actions by putting a delay inside a watcher Saga.
-For example suppose the UI fires an `INPUT_CHANGED` action while the user is typing in a text
-field.
+You can throttle a sequence of dispatched actions by putting a delay inside a watcher Saga. For example, suppose the UI fires an `INPUT_CHANGED` action while the user is typing in a text field.
 
 ```javascript
-
 const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 
 function* handleInput(input) {
-  ...
+  // ...
 }
 
 function* watchInput() {
-  while(true) {
+  while (true) {
     const { input } = yield take('INPUT_CHANGED')
     yield fork(handleInput, input)
     // throttle by 500ms
@@ -24,18 +21,11 @@ function* watchInput() {
 }
 ```
 
-By putting a delay after the `fork`, the `watchInput` will be blocked for 500ms so it'll miss
-all `INPUT_CHANGED` actions happening in-between. This ensures that the Saga will take at most
-one `INPUT_CHANGED` action during each period of 500ms.
+By putting a delay after the `fork`, the `watchInput` will be blocked for 500ms so it'll miss all `INPUT_CHANGED` actions happening in-between. This ensures that the Saga will take at most one `INPUT_CHANGED` action during each period of 500ms.
 
-But there is a subtle issue with the above code. After taking an action, `watchInput` will
-sleep for 500ms, which means it'll miss all actions that occurred in this period. That may be the
-purpose for throttling, but note the watcher will also miss the trailer action: i.e. the last
-action that may eventually occur in the 500ms interval. If you are throttling input actions on
-a text field, this may be undesirable, because you'll likely want to react to the last input after
-the 500ms throttling delay has passed.
+But there is a subtle issue with the above code. After taking an action, `watchInput` will sleep for 500ms, which means it'll miss all actions that occurred in this period. That may be the purpose for throttling, but note the watcher will also miss the trailer action: i.e. the last action that may eventually occur in the 500ms interval. If you are throttling input actions on a text field, this may be undesirable, because you'll likely want to react to the last input after the 500ms throttling delay has passed.
 
-Here is a more elaborated version which keeps track of the trailing action
+Here is a more elaborate version which keeps track of the trailing action:
 
 ```javascript
 function* watchInput(wait) {
@@ -43,7 +33,7 @@ function* watchInput(wait) {
   let lastTime = Date.now()
   let countDown = 0 // handle leading action
 
-  while(true) {
+  while (true) {
     const winner = yield race({
       action: take('INPUT_CHANGED'),
       timeout: countDown ? call(delay, countDown) : null
@@ -52,10 +42,10 @@ function* watchInput(wait) {
     countDown -= (now - lastTime)
     lastTime = now
 
-    if(winner.action) {
+    if (winner.action) {
       lastAction = action
     }
-    if(lastAction && countDown <= 0) {
+    if (lastAction && countDown <= 0) {
       yield fork(worker, lastAction)
       lastAction = null
       countDown = wait
@@ -64,26 +54,15 @@ function* watchInput(wait) {
 }
 ```
 
-In the new version we maintain a `countDown` variable which tracks the remaining timeout.
-Initially the `countDown` is `0` because we want to handle the first action. After handling the
-first action, the countDown will be set to the throttling period `wait`. Which means we'll have to
-wait at least for `wait`ms before handling a next action.
+In the new version, we maintain a `countDown` variable which tracks the remaining timeout. Initially the `countDown` is `0` because we want to handle the first action. After handling the first action, the `countDown` will be set to the throttling period `wait`. Which means we'll have to wait at least for `wait` ms before handling a next action.
 
-Then at each iteration, we start a race between the next eventual action and the remaining timeout. Now we
-don't miss any action, instead we keep track of the last one in the `lastAction` variable, and we also update
-the countDown with remaining timeout.
+Then at each iteration, we start a race between the next eventual action and the remaining timeout. Now we don't miss any action, instead we keep track of the last one in the `lastAction` variable, and we also update the countDown with remaining timeout.
 
-The `if(lastAction && countDown <= 0) {...}` block ensures that we can handle an eventual
-trailing action (if `lastAction` is not null/undefined) after the throttling period expired
-(if `countDown` is less or equal than 0). Immediately after handling the action, we reset the
-`lastAction` and `countDown`. So we'll now have to wait for another `wait`ms period for another
-action to handle it.   
+The `if (lastAction && countDown <= 0) {...}` block ensures that we can handle an eventual trailing action (if `lastAction` is not null/undefined) after the throttling period expired (if `countDown` is less or equal than 0). Immediately after handling the action, we reset the `lastAction` and `countDown`. So we'll now have to wait for another `wait` ms period for another action to handle it.
 
+## Debouncing
 
-
-### Debouncing
-
-To debounce the sequence you put the `delay` in the forked task
+To debounce a sequence, put the `delay` in the forked task:
 
 ```javascript
 
@@ -97,16 +76,14 @@ function* handleInput(input) {
 
 function* watchInput() {
   let task
-  while(true) {
+  while (true) {
     const { input } = yield take('INPUT_CHANGED')
-    if(task)
+    if (task) {
       yield cancel(task)
+    }
     task = yield fork(handleInput, input)
   }
 }
 ```
 
-In the above example `handleInput` waits for 500ms before performing its logic. If the user
-types something during this period we'll get more `INPUT_CHANGED` actions. Since `handleInput`
-will still be blocked in the `delay` call, it'll be cancelled by `watchInput` before it can start
-performing its logic.
+In the above example `handleInput` waits for 500ms before performing its logic. If the user types something during this period we'll get more `INPUT_CHANGED` actions. Since `handleInput` will still be blocked in the `delay` call, it'll be cancelled by `watchInput` before it can start performing its logic.


### PR DESCRIPTION
Hi @yelouafi! Thanks for the amazing work on this library.

This PR contains a big clean-up of the docs. Specifically, it addresses:

##### Spelling/grammar

- Fix various typos and grammatical mistakes
- Use slightly more formal language where appropriate
- Ensure consistent punctuation

##### Consistency

- Switch to single-line paragraphs (currently, this is all over the place: some lines are capped at 80 chars, some at 100, and some not at all, so I switched to the most widely-used style in the JS community)
- Ensure that doc titles are consistent with their README links
- Ensure consistent title capitalization
- Ensure two-line spacing between paragraphs and code

##### Example code

- Ensure consistent use of `while ()` and `if ()`
- Fix a few syntax errors
- Ensure consistent comment spacing
- Use `sh` templates for console commands