### PR TITLE
Rename .eslintrc (deprecated) to .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,5 @@
     "node": true,
     "es6": true
   },
-
   "parser": "babel-eslint"
 }


### PR DESCRIPTION
A tiny clean up: the `.eslintrc` format [is deprecated](http://eslint.org/docs/user-guide/configuring#configuration-file-formats), so this PR renames it to `.eslintrc.json`.