### PR TITLE
log error for check

### DIFF
--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -12,8 +12,10 @@ export function ident(v) {
 export const isDev = typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'development'
 
 export function check(value, predicate, error) {
-  if(! predicate(value) )
+  if(!predicate(value)) {
+    log('error', 'uncaught at check', error)
     throw new Error(error)
+  }
 }
 
 export const is = {


### PR DESCRIPTION
The type check would be suppressed if it failed in a try-catch block:

```
  try {
    const json = yield call(fetch(target).then(resp => resp.json())) // wrong, it should be a function instead of a promise
  } catch (e) {
    yield put({type: 'FETCH_FAILED', message: e.message})
  }
```

There is no difference between the error from internal check and the exception from rejection. It's a little confusing for newcomers.