### PR TITLE
fix anchor link to delay(ms, [val])

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -41,7 +41,7 @@
   * [`channel([buffer])`](#channelbuffer)
   * [`eventChannel(subscribe, [buffer], matcher)`](#eventchannelsubscribebuffermatcher)
   * [`buffers`](#buffers)
-  * [`delay(ms, [val])`](#delaymsval)
+  * [`delay(ms, [val])`](#delayms-val)
 
 ## Middleware API
 


### PR DESCRIPTION
This pull request fixes the anchor link to the `delay(ms, [val])` function description.