### PR TITLE
Throw errors outside Promise chain.

### DIFF
--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -106,6 +106,9 @@ export function log(level, message, error) {
   if(typeof window === 'undefined') {
     console.log(`redux-saga ${level}: ${message}\n${(error && error.stack) || error}`)
   } else {
+    if (level === 'error') {
+      setTimeout(() => { throw error })
+    }
     console[level].call(console, message, error)
   }
 }


### PR DESCRIPTION
In my apps I use window.onerror to log uncaught exceptions to the
back-end. However uncaught exceptions does not get processed by
`window.onerror` but is instead logged with `console.error`.

The setTimeout trick runs the function in the event loop outside the
Promise. Since the error is uncaught it gets processed by
`window.onerror`, and produces a clickable stack-trace in the console.