### PR TITLE
Update docs to reference included delay effect

### DIFF
--- a/docs/advanced/RacingEffects.md
+++ b/docs/advanced/RacingEffects.md
@@ -9,6 +9,7 @@ The following sample shows a task that triggers a remote fetch request, and cons
 
 ```javascript
 import { race, take, put } from 'redux-saga/effects'
+import { delay } from 'redux-saga'
 
 function* fetchPostsWithTimeout() {
   const {posts, timeout} = yield race({

--- a/docs/advanced/TaskCancellation.md
+++ b/docs/advanced/TaskCancellation.md
@@ -10,8 +10,8 @@ The task will execute continually until a `STOP_BACKGROUND_SYNC` action is trigg
 
 ```javascript
 import {  take, put, call, fork, cancel, cancelled } from 'redux-saga/effects'
-import actions from 'somewhere'
-import { someApi, delay } from 'somewhere'
+import { delay } from 'redux-saga'
+import { someApi, actions } from 'somewhere'
 
 function* bgSync() {
   try {


### PR DESCRIPTION
The current docs either don't tell where the delay effect is coming from or import it from 'somewhere'. Since delay is included by default in redux-saga we should update the docs to clear this up.

Some docs (recipes) which include an inline example of a delay effect haven't been amended.