### PR TITLE
add missing package in real-world example

### DIFF
--- a/examples/real-world/package.json
+++ b/examples/real-world/package.json
@@ -35,6 +35,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
+    "babel-register": "^6.9.0",
     "concurrently": "^0.1.1",
     "express": "^4.13.3",
     "redux-devtools": "^3.0.0-beta-3",


### PR DESCRIPTION
notice that babel-register was missing