### PR TITLE
Update docs replacing getState with select

### DIFF
--- a/docs/advanced/FutureActions.md
+++ b/docs/advanced/FutureActions.md
@@ -12,11 +12,14 @@ Using `takeEvery('*')` (with the wildcard `*` pattern) we can catch all dispatch
 
 ```javascript
 import { takeEvery } from 'redux-saga'
+import { put, select } from 'redux-saga/effects'
 
-function* watchAndLog(getState) {
+function* watchAndLog() {
   yield* takeEvery('*', function* logger(action) {
+    const state = yield select()
+    
     console.log('action', action)
-    console.log('state after', getState())
+    console.log('state after', state)
   })
 }
 ```
@@ -25,12 +28,15 @@ Now let's see how to use the `take` Effect to implement the same flow as above
 
 ```javascript
 import { take } from 'redux-saga/effects'
+import { put, select } from 'redux-saga/effects'
 
-function* watchAndLog(getState) {
+function* watchAndLog() {
   while (true) {
     const action = yield take('*')
+    const state = yield select()
+
     console.log('action', action)
-    console.log('state after', getState())
+    console.log('state after', state)
   }
 }
 ```


### PR DESCRIPTION
I noticed that the docs are still using `getState` argument of Sagas, deprecated in 0.10. Since I'm new to `redux-saga` I'd like to receive a feedback before continuing the update. Am I doing it right?
Thanks.

Related also to #286 