### PR TITLE
use reduce instead of forEach.

### DIFF
--- a/examples/real-world/actions/index.js
+++ b/examples/real-world/actions/index.js
@@ -4,9 +4,10 @@ const SUCCESS = 'SUCCESS'
 const FAILURE = 'FAILURE'
 
 function createRequestTypes(base) {
-  const res = {};
-  [REQUEST, SUCCESS, FAILURE].forEach(type => res[type] = `${base}_${type}`)
-  return res;
+  return [REQUEST, SUCCESS, FAILURE].reduce((acc, type) => {
+		acc[type] = `${base}_${type}`
+		return acc
+	}, {})
 }
 
 export const USER = createRequestTypes('USER')


### PR DESCRIPTION
To my mind, `reduce()` is greatly preferred when transforming data, rather than just looping over it. What do you think?