### PR TITLE
Introduce effectsSuspended hook

### DIFF
--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -252,6 +252,9 @@ export default function proc(
   }
 
   function runEffect(effect, parentEffectId, label = '', cb) {
+    if (monitor && monitor.effectsSuspended()) {
+      return;
+    }
     const effectId = nextEffectId()
     monitor && monitor.effectTriggered({effectId, parentEffectId, label, effect})
 


### PR DESCRIPTION
Fixes #399.

This allows for an `effectsSuspended` hook to be attached to the SagaMonitor object. This hook will be called in `runEffect` and returns a boolean. If `true` then the processing of the side effect will be cancelled. This helps with time travel debugging or replaying a Redux log during a test suite, where triggering side effects is not desirable.

Example:

```
const sagaMiddleware = createSagaMiddleware({
  effectsSuspended() {
    // imaginary selector
    if (noSideEffectsAllowed(store.getState()) {
      return true;
    }
    return false;
  }
});
```