### PR TITLE
Fixed examples hot reload method.

### DIFF
--- a/examples/async/webpack.config.js
+++ b/examples/async/webpack.config.js
@@ -4,7 +4,7 @@ var webpack = require('webpack')
 module.exports = {
   devtool: 'cheap-module-eval-source-map',
   entry: [
-    'webpack-hot-middleware/client',
+    'webpack-hot-middleware/client?reload=true',
     path.join(__dirname, 'src', 'main')
   ],
   output: {

--- a/examples/cancellable-counter/webpack.config.js
+++ b/examples/cancellable-counter/webpack.config.js
@@ -4,7 +4,7 @@ var webpack = require('webpack')
 module.exports = {
   devtool: 'cheap-module-eval-source-map',
   entry: [
-    'webpack-hot-middleware/client',
+    'webpack-hot-middleware/client?reload=true',
     path.join(__dirname, 'src', 'main')
   ],
   output: {

--- a/examples/counter/webpack.config.js
+++ b/examples/counter/webpack.config.js
@@ -4,7 +4,7 @@ var webpack = require('webpack')
 module.exports = {
   devtool: 'cheap-module-eval-source-map',
   entry: [
-    'webpack-hot-middleware/client',
+    'webpack-hot-middleware/client?reload=true',
     path.join(__dirname, 'src', 'main')
   ],
   output: {

--- a/examples/real-world/webpack.config.js
+++ b/examples/real-world/webpack.config.js
@@ -4,7 +4,7 @@ var webpack = require('webpack')
 module.exports = {
   devtool: 'cheap-module-eval-source-map',
   entry: [
-    'webpack-hot-middleware/client',
+    'webpack-hot-middleware/client?reload=true',
     path.join(__dirname, 'index')
   ],
   output: {

--- a/examples/shopping-cart/webpack.config.js
+++ b/examples/shopping-cart/webpack.config.js
@@ -4,7 +4,7 @@ var webpack = require('webpack')
 module.exports = {
   devtool: 'cheap-module-eval-source-map',
   entry: [
-    'webpack-hot-middleware/client',
+    'webpack-hot-middleware/client?reload=true',
     path.join(__dirname, 'src', 'main')
   ],
   output: {


### PR DESCRIPTION
### Story / Defect
some modules can't hot reload for develop
#370 

### Changes
updated examples's webpack.config
`'webpack-hot-middleware/client'`
to
` 'webpack-hot-middleware/client?reload=true'`

### Test
When you encounter hot reload fail, it will full reload page.