### PR TITLE
Fix link in API Reference

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -12,7 +12,7 @@
   * [`take(channel)`](#takechannel)
   * [`takem(channel)`](#takemchannel)
   * [`put(action)`](#putaction)
-  * [`put(channel, action)`](#putchannelaction)
+  * [`put(channel, action)`](#putchannel-action)
   * [`call(fn, ...args)`](#callfn-args)
   * [`call([context, fn], ...args)`](#callcontext-fn-args)
   * [`apply(context, fn, args)`](#applycontext-fn-args)


### PR DESCRIPTION
The destination tag of `put(channel, action)` is `<h3 id="putchannel-action">`. I fixed the link to match its id.