### PR TITLE
fix multiple default exports in shopping-cart example

### DIFF
--- a/examples/shopping-cart/src/components/ProductList.js
+++ b/examples/shopping-cart/src/components/ProductList.js
@@ -6,7 +6,7 @@ import { addToCart } from '../actions'
 import { getVisibleProducts } from '../reducers/products'
 
 
-export default class ProductList extends Component {
+class ProductList extends Component {
   render() {
     const { products, addToCart } = this.props
 


### PR DESCRIPTION
Fixes this problem with `npm run shop`

` SyntaxError: Only one default export allowed per module.`

<img width="535" alt="screen shot 2016-09-01 at 12 48 22 pm" src="https://cloud.githubusercontent.com/assets/4691093/18176394/66a0d6b8-7043-11e6-82b8-78e3a70b2fe0.png">
