### PR TITLE
[bugfix] log() compatible with IE9

### DIFF
--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -107,7 +107,7 @@ export function log(level, message, error) {
   if(typeof window === 'undefined') {
     console.log(`redux-saga ${level}: ${message}\n${(error && error.stack) || error}`)
   } else {
-    console[level].call(console, message, error)
+    console[level](message, error)
   }
 }
 


### PR DESCRIPTION
In Internet Explorer 9
`typeof console.info.call === 'undefined'`
Any cancel effect will call log('info', ...) finally cause exception and break tasks.