### PR TITLE
Don't cancel saga when put dispatch throws

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -312,6 +312,8 @@ Same as `take(channel)` but does not automatically terminate the Saga on an `END
 ### `put(action)`
 
 Creates an Effect description that instructs the middleware to dispatch an action to the Store.
+This effect is non-blocking and any errors that are thrown downstream (e.g. in a reducer) will
+not bubble back into the saga.
 
 - `action: Object` - [see Redux `dispatch` documentation for complete info](http://redux.js.org/docs/api/Store.html#dispatch)
 
@@ -321,6 +323,9 @@ Creates an Effect description that instructs the middleware to put an action int
 
 - `channel: Channel` - a [`Channel`](#channel) Object.
 - `action: Object` - [see Redux `dispatch` documentation for complete info](http://redux.js.org/docs/api/Store.html#dispatch)
+
+This effect is blocking if the put is *not* buffered but immediately consumed by takers. If an error
+is thrown in any of these takers it will bubble back into the saga.
 
 ### `call(fn, ...args)`
 

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -442,7 +442,7 @@ export default function proc(
       } catch(error) {
         // If we have a channel or `put.sync` was used then bubble up the error.
         if (channel || sync) return cb(error, true)
-        log('error', `uncaught at ${name}`, error.stack)
+        log('error', `uncaught at ${name}`, error.stack || error.message || error)
       }
 
       if(sync && is.promise(result)) {

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -440,7 +440,8 @@ export default function proc(
       try {
         result = (channel ? channel.put : dispatch)(action)
       } catch(error) {
-        return cb(error, true)
+        if (channel) return cb(error, true)
+        log('error', `uncaught at ${name}`, error.message)
       }
 
       if(sync && is.promise(result)) {

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -441,7 +441,7 @@ export default function proc(
         result = (channel ? channel.put : dispatch)(action)
       } catch(error) {
         if (channel) return cb(error, true)
-        log('error', `uncaught at ${name}`, error.message)
+        log('error', `uncaught at ${name}`, error.stack)
       }
 
       if(sync && is.promise(result)) {

--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -440,7 +440,8 @@ export default function proc(
       try {
         result = (channel ? channel.put : dispatch)(action)
       } catch(error) {
-        if (channel) return cb(error, true)
+        // If we have a channel or `put.sync` was used then bubble up the error.
+        if (channel || sync) return cb(error, true)
         log('error', `uncaught at ${name}`, error.stack)
       }
 


### PR DESCRIPTION
Ref #550 

When putting onto the store via dispatch the operation should be considered an emit on the Redux store that does not bubble up errors from reducers/helpers/etc. subsequently cancelling the saga.

This patch simply logs such errors and renders the put as a noop.