### PR TITLE
Call cancel on CPS function cancellation

### DIFF
--- a/src/internal/proc.js
+++ b/src/internal/proc.js
@@ -475,9 +475,11 @@ export default function proc(
 
     // catch synchronous failures; see #152
     try {
-      fn.apply(context, args.concat(
-        (err, res) => is.undef(err) ? cb(res) : cb(err, true)
-      ))
+      const cpsCb = (err, res) => is.undef(err) ? cb(res) : cb(err, true);
+      fn.apply(context, args.concat(cpsCb));
+      if (cpsCb.cancel) {
+        cb.cancel = () => cpsCb.cancel();
+      }
     } catch(error) {
       return cb(error, true)
     }


### PR DESCRIPTION
According to comments in the source, cps functions should be able to add their
cancellation logic. However, that does not work at the moment. This pull-request
fixes that.