### PR TITLE
Fix broken links and minor grammar error

### DIFF
--- a/docs/advanced/Channels.md
+++ b/docs/advanced/Channels.md
@@ -59,7 +59,7 @@ Next is the `yield take(requestChan)`. Besides usage with a `pattern` to take sp
 
 The important thing to note is how we're using a blocking `call`. The Saga will remain blocked until `call(handleRequest)` returns. But meanwhile, if other `REQUEST` actions are dispatched while the Saga is still blocked, they will queued internally by `requestChan`. When the Saga resumes from `call(handleRequest)` and executes the next `yield take(requestChan)`, the take will resolve with the queued message.
 
-By default, `actionChannel` buffers all incoming messages without limit. If you want a more control over the buffering, you can supply a Buffer argument to the effect creator. Redux-Saga provides some common buffers (none, dropping, sliding) but you can also supply your own buffer implementation. [See API docs](redux-saga/docs/api/index.html#buffers) for more details.
+By default, `actionChannel` buffers all incoming messages without limit. If you want a more control over the buffering, you can supply a Buffer argument to the effect creator. Redux-Saga provides some common buffers (none, dropping, sliding) but you can also supply your own buffer implementation. [See API docs](../api#buffers) for more details.
 
 For example if you want to handle only the most recent five items you can use:
 
@@ -132,7 +132,7 @@ export function* saga() {
 }
 ```
 
-So the Saga is yielding a `take(chan)`. This causes the Saga to block until a message is putted on the channel. In our example above, it corresponds to when we invoke `emitter(secs)`. Note also we're executing the whole `while (true) {...}` loop inside a `try/finally` block. When the interval terminates, the countdown function closes the event channel by invoking `emitter(END)`. Closing a channel has the effect of terminating all Sagas blocked on a `take` from that channel. In our example, terminating the Saga will cause it to jump to its `finally` block (if provided, otherwise the Saga simply terminates).
+So the Saga is yielding a `take(chan)`. This causes the Saga to block until a message is put on the channel. In our example above, it corresponds to when we invoke `emitter(secs)`. Note also we're executing the whole `while (true) {...}` loop inside a `try/finally` block. When the interval terminates, the countdown function closes the event channel by invoking `emitter(END)`. Closing a channel has the effect of terminating all Sagas blocked on a `take` from that channel. In our example, terminating the Saga will cause it to jump to its `finally` block (if provided, otherwise the Saga simply terminates).
 
 The subscriber returns an `unsubscribe` function. This is used by the channel to unsubscribe before the event source complete. Inside a Saga consuming messages from an event channel, if we want to *exit early* before the event source complete (e.g. Saga has been cancelled) you can call `chan.close()` to close the channel and unsubscribe from the source.
 
@@ -215,7 +215,7 @@ export function* watchOnPings() {
 ```
 
 > Note: messages on an eventChannel are not buffered by default. You have to provide a buffer to the eventChannel factory in order to specify buffering strategy for the channel (e.g. `eventChannel(subscriber, buffer)`).
-[See the API docs](/redux-saga/docs/api/index.html#buffers) for more info.
+[See the API docs](../api#buffers) for more info.
 
 ### Using channels to communicate between Sagas
 


### PR DESCRIPTION
- There were two broken links to the "buffers" section of API
- "putted" -> "put"