### PR TITLE
[Typescript] SagaIterator: Iterable -> IterableIterator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ import {Task, Buffer, Channel, Predicate} from "./types";
 
 export {Effect, Pattern, Task, Buffer, Channel, Predicate};
 
-export type SagaIterator = Iterable<Effect|Effect[]>;
+export type SagaIterator = IterableIterator<Effect|Effect[]>;
 
 type Saga0 = () => SagaIterator; 
 type Saga1<T1> = (arg1: T1) => SagaIterator; 


### PR DESCRIPTION
Currently when I have a saga like this:

```ts
function* saga(): SagaIterator {
  for(;;) {
    const {end} = yield race({
      timeout: call(delay, 4000),
      end: take([`${previousColor}`, `${nextColor}`]),
    })
    if(end) { break }
    yield put(autoNextColor())
  }
}
```

The following results in `next` being undefined when testing:

```ts
const generator = saga()
generator.next() // Property 'next' does not exist on type 'Iterable<TakeEffect<any> | ...>'.
```

Using `IterableIterator` instead of `Iterable` works as the type of a regular generator function is an `IterableIterator`.