### PR TITLE
Clarify the argument to expanding buffers

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -942,7 +942,7 @@ Provides some common buffers
 
 - `buffers.fixed(limit)`: new messages will be buffered up to `limit`. Overflow will raises an Error. Omitting a `limit` value will result in a limit of 10.
 
-- `buffers.expanding(limit)`: like `fixed` but Overflow will cause the buffer to expand dynamically.
+- `buffers.expanding(initialSize)`: like `fixed` but Overflow will cause the buffer to expand dynamically.
 
 - `buffers.dropping(limit)`: same as `fixed` but Overflow will silently drop the messages.
 

--- a/src/internal/buffers.js
+++ b/src/internal/buffers.js
@@ -82,5 +82,5 @@ export const buffers = {
   fixed: limit => ringBuffer(limit, ON_OVERFLOW_THROW),
   dropping: limit => ringBuffer(limit, ON_OVERFLOW_DROP),
   sliding: limit => ringBuffer(limit, ON_OVERFLOW_SLIDE),
-  expanding: limit => ringBuffer(limit, ON_OVERFLOW_EXPAND)
+  expanding: initialSize => ringBuffer(initialSize, ON_OVERFLOW_EXPAND)
 }


### PR DESCRIPTION
Currently docs suggest it expands dynamically to the limit provided, instead of its behavior which is to be initialized with a given size.