### PR TITLE
Add missing yield in fork model example

### DIFF
--- a/docs/advanced/ForkModel.md
+++ b/docs/advanced/ForkModel.md
@@ -115,7 +115,7 @@ function* fetchResource(resource) {
 
 function* main() {
   try {
-    call(fetchAll)
+    yield call(fetchAll)
   } catch (e) {
     // handle fetchAll errors
   }


### PR DESCRIPTION
From what I can see there should be a `yield` here, as `call` doesn't actually do anything without it - and it should be the same as the example above right?