### PR TITLE
Missing a babel-register

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "homepage": "https://github.com/yelouafi/redux-saga#readme",
   "dependencies": {},
   "devDependencies": {
+    "babel-register": "^6.18.0",
     "babel-cli": "^6.1.18",
     "babel-core": "^6.14.0",
     "babel-eslint": "^6.0.3",


### PR DESCRIPTION
 After run `npm install`, when I run `npm run real-world`，it will go wrong said that can not find `babel-register`,
when I add this package, it works well.