### PR TITLE
Saga Error Handling Example

### DIFF
--- a/examples/async/src/actions/index.js
+++ b/examples/async/src/actions/index.js
@@ -1,8 +1,9 @@
-
 export const REQUEST_POSTS = 'REQUEST_POSTS'
 export const RECEIVE_POSTS = 'RECEIVE_POSTS'
 export const SELECT_REDDIT = 'SELECT_REDDIT'
 export const INVALIDATE_REDDIT = 'INVALIDATE_REDDIT'
+export const SET_ERROR = 'SET_ERROR'
+export const CLEAR_ERROR = 'CLEAR_ERROR'
 
 export function selectReddit(reddit) {
   return {
@@ -31,5 +32,18 @@ export function receivePosts(reddit, posts) {
     reddit,
     posts,
     receivedAt: Date.now()
+  }
+}
+
+export function setError(errorMessage) {
+  return {
+    type: SET_ERROR,
+    errorMessage
+  }
+}
+
+export function clearError() {
+  return {
+    type: CLEAR_ERROR
   }
 }

--- a/examples/async/src/containers/App.js
+++ b/examples/async/src/containers/App.js
@@ -22,12 +22,21 @@ class App extends Component {
   }
 
   render() {
-    const { selectedReddit, posts, isFetching, lastUpdated } = this.props
+    const { selectedReddit, posts, isFetching, lastUpdated, errorMessage } = this.props
     return (
       <div>
+        { errorMessage &&
+          <p>
+            Something bad happened:
+            <br/>
+            {errorMessage}
+            <br/>
+            Please try again
+          </p>
+        }
         <Picker value={selectedReddit}
                 onChange={this.handleChange}
-                options={[ 'reactjs', 'frontend' ]} />
+                options={[ 'reactjs', 'frontend', 'simulate network failure' ]} />
         <p>
           {lastUpdated &&
             <span>
@@ -67,7 +76,7 @@ App.propTypes = {
 }
 
 function mapStateToProps(state) {
-  const { selectedReddit, postsByReddit } = state
+  const { selectedReddit, postsByReddit, errorMessage } = state
   const {
     isFetching,
     lastUpdated,
@@ -81,7 +90,8 @@ function mapStateToProps(state) {
     selectedReddit,
     posts,
     isFetching,
-    lastUpdated
+    lastUpdated,
+    errorMessage
   }
 }
 

--- a/examples/async/src/reducers/index.js
+++ b/examples/async/src/reducers/index.js
@@ -2,7 +2,9 @@ import { combineReducers } from 'redux'
 import {
   SELECT_REDDIT,
   REQUEST_POSTS,
-  RECEIVE_POSTS
+  RECEIVE_POSTS,
+  SET_ERROR,
+  CLEAR_ERROR
 } from '../actions'
 
 function selectedReddit(state = 'reactjs', action) {
@@ -35,7 +37,6 @@ function posts(state = {
 
 function postsByReddit(state = { }, action) {
   switch (action.type) {
-    case REQUEST_POSTS:
     case RECEIVE_POSTS:
       return { ...state,
         [action.reddit]: posts(state[action.reddit], action)
@@ -45,9 +46,21 @@ function postsByReddit(state = { }, action) {
   }
 }
 
+function errorMessage(state = null, action) {
+  switch (action.type) {
+    case SET_ERROR:
+      return action.errorMessage
+    case CLEAR_ERROR:
+      return null
+    default:
+      return state
+  }
+}
+
 const rootReducer = combineReducers({
   postsByReddit,
-  selectedReddit
+  selectedReddit,
+  errorMessage
 })
 
 export default rootReducer

--- a/examples/async/src/sagas/index.js
+++ b/examples/async/src/sagas/index.js
@@ -1,15 +1,17 @@
 /* eslint-disable no-constant-condition */
-
-
-import { take, put, call, fork, select } from '../../../../src/effects'
+import { take, put, call, fork, spawn, select } from '../../../../src/effects'
 import fetch from 'isomorphic-fetch'
 import * as actions from '../actions'
 import { selectedRedditSelector, postsByRedditSelector } from '../reducers/selectors'
 
 export function fetchPostsApi(reddit) {
+  if (reddit === 'simulate network failure') {
+    throw new Error('Failed to fetch')
+  } else {
     return fetch(`http://www.reddit.com/r/${reddit}.json` )
-            .then(response => response.json() )
-            .then(json => json.data.children.map(child => child.data) )
+      .then(response => response.json() )
+      .then(json => json.data.children.map(child => child.data) )
+  }
 }
 
 export function* fetchPosts(reddit) {
@@ -21,6 +23,7 @@ export function* fetchPosts(reddit) {
 export function* invalidateReddit() {
   while (true) {
     const {reddit} = yield take(actions.INVALIDATE_REDDIT)
+    yield put(actions.clearError())
     yield call( fetchPosts, reddit )
   }
 }
@@ -29,11 +32,13 @@ export function* nextRedditChange() {
   while(true) {
     const prevReddit = yield select(selectedRedditSelector)
     yield take(actions.SELECT_REDDIT)
+    yield put(actions.clearError())
 
     const newReddit = yield select(selectedRedditSelector)
     const postsByReddit = yield select(postsByRedditSelector)
-    if(prevReddit !== newReddit && !postsByReddit[newReddit])
-      yield fork(fetchPosts, newReddit)
+    if(prevReddit !== newReddit && !postsByReddit[newReddit]) {
+      yield call(fetchPosts, newReddit)
+    }
   }
 }
 
@@ -44,6 +49,23 @@ export function* startup() {
 
 export default function* root() {
   yield fork(startup)
-  yield fork(nextRedditChange)
-  yield fork(invalidateReddit)
+  const sagas = [nextRedditChange, invalidateReddit]
+
+  yield sagas.map(saga =>
+    spawn(function* () {
+      let isSyncError = false
+      while (!isSyncError) {
+        isSyncError = true
+        try {
+          setTimeout(() => isSyncError = false)
+          yield call(saga)
+        } catch (e) {
+          if (isSyncError) {
+            throw new Error(saga.name + ' was terminated because it threw an exception on startup.')
+          }
+          yield put(actions.setError(e.message))
+        }
+      }
+    })
+  )
 }

--- a/examples/async/webpack.config.js
+++ b/examples/async/webpack.config.js
@@ -2,7 +2,7 @@ var path = require('path')
 var webpack = require('webpack')
 
 module.exports = {
-  devtool: 'cheap-module-eval-source-map',
+  devtool: 'inline-source-map',
   entry: [
     'webpack-hot-middleware/client?reload=true',
     path.join(__dirname, 'src', 'main')


### PR DESCRIPTION
Use spawn to start sagas so that an uncaught exception doesn't terminate all of them. Restart a saga on an asynchronous exception. Terminate it on a sync exception.

If you simply `yield call` your sagas within your root saga, then any uncaught exception in any of them will kill all of them, making your app unresponsive. To isolate each saga from the others, I use `spawn`. This way, an error in one doesn't affect any of the others, and they remain responsive.

However, we still don't want the saga that had an uncaught exception to die because maybe some crazy async error was thrown that we somehow didn't add specific handling for. To deal with this, we can add a `while (true) { try { yield call(saga) } catch (e) { } }` that will restart the saga after handling its error. But if the error is simply something that is thrown when the saga starts (we make a typo during development, for example, and try to access a property from undefined), we don't want to start this saga, causing it to immediately throw the error, catch the error, and repeat forever. To check if the error is sync, I added the `isSyncError` flag that only gets set to `false` in a deferred manner, after the current stack is cleared, via `setTimeout`.

I've wrestled with this problem quite a bit, and I can't come up with any better solution. I would be happy to see some alternatives, but this is a significant pain point that just isn't addressed in any of the documentation or examples. Therefore, I think we need to offer an idiomatic way of solving it in this example.

This is a resurrection of #610, which I had closed in order to get a different pull request in in the meantime (can't have two PRs at once).