### PR TITLE
Docs cleanup: Removes reference to unused import 

### DIFF
--- a/docs/basics/UsingSagaHelpers.md
+++ b/docs/basics/UsingSagaHelpers.md
@@ -53,7 +53,6 @@ For example:
 
 ```javascript
 import { takeEvery } from 'redux-saga'
-import { fork } from 'redux-saga/effects'
 
 // FETCH_USERS
 function* fetchUsers(action) { ... }


### PR DESCRIPTION
Small docs eslint-ish fix. The example code was importing `fork` but the code isn't referencing it.  