### PR TITLE
Update docs to avoid confusion over saga helper implementations

### DIFF
--- a/docs/advanced/Concurrency.md
+++ b/docs/advanced/Concurrency.md
@@ -2,7 +2,7 @@
 
 In the basics section, we saw how to use the helper effects `takeEvery` and `takeLatest` in order to manage concurrency between Effects.
 
-In this section we'll see how those helpers are implemented using the low-level Effects.
+In this section we'll see how those helpers could be implemented using the low-level Effects.
 
 ## `takeEvery`
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -148,7 +148,7 @@ function* watchFetchUser() {
 
 #### Notes
 
-`takeEvery` is a high-level API built using `take` and `fork`. Here is how the helper is implemented:
+`takeEvery` is a high-level API built using `take` and `fork`. Here is how the helper could be implemented using the low-level Effects
 
 ```javascript
 function* takeEvery(pattern, saga, ...args) {
@@ -208,7 +208,7 @@ function* watchLastFetchUser() {
 
 #### Notes
 
-`takeLatest` is a high-level API built using `take` and `fork`. Here is how the helper is implemented
+`takeLatest` is a high-level API built using `take` and `fork`. Here is how the helper could be implemented using the low-level Effects
 
 ```javascript
 function* takeLatest(pattern, saga, ...args) {
@@ -259,7 +259,7 @@ function* throttleAutocomplete() {
 
 #### Notes
 
-`throttle` is a high-level API built using `take`, `fork` and `actionChannel`. Here is how the helper is implemented
+`throttle` is a high-level API built using `take`, `fork` and `actionChannel`. Here is how the helper could be implemented using the low-level Effects
 
 ```javascript
 function* throttle(ms, pattern, task, ...args) {


### PR DESCRIPTION
This is a small documentation update that attempts to reduce confusion about the implementation of the saga helpers. They are no longer actually implemented as generators. However, my understanding is that the examples in the docs are meant more as higher level illustrations of how the saga helpers could be implemented.