### PR TITLE
[TypeScript] add root flag to monitor interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ export interface Monitor {
     effectId: number;
     parentEffectId: number;
     label: string;
+    root?: boolean;
     effect: Effect;
   }): void;
 


### PR DESCRIPTION
@aikoven pls, have a look.
also seems [this definition](https://github.com/restrry/redux-saga/blob/71221f8b4960f8d67e01ef1535880baef93305d9/index.d.ts#L24) should be extended with [that effect descriptor.](https://github.com/yelouafi/redux-saga/blob/75c84580dae95399e55e5ae25a0b3f7b2113b46e/src/internal/middleware.js#L85)  isn't?