### PR TITLE
blocking/non-blocking effect. fix table and link in docs

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -48,7 +48,7 @@
 
 # Cheatsheets
 
-* [Blocking / Non-blocking](#blockingnonblocking)
+* [Blocking / Non-blocking](#blocking--non-blocking)
 
 ## Middleware API
 
@@ -978,7 +978,7 @@ Returns a Promise that will resolve after `ms` milliseconds with `val`.
 ### Blocking / Non-blocking
 
 | Name | Blocking |
-| -- | -- |
+| --- | --- |
 | takeEvery | No |
 | takeLatest | No |
 | throttle | Yes |


### PR DESCRIPTION
according to [docs](https://help.github.com/articles/organizing-information-with-tables/#creating-a-table) table header row should has at least 3 hyphens. also link in docs is broken